### PR TITLE
Ben connection enhance

### DIFF
--- a/src/Interface/Application/Connection.h
+++ b/src/Interface/Application/Connection.h
@@ -42,7 +42,6 @@ namespace SCIRun {
 namespace Gui {
 
 class PortWidget;
-class ModuleWidget; 
 
 class ConnectionDrawStrategy
 {


### PR DESCRIPTION
I have all(most) of the code I added in comments. The collision detection is slow, but will wrap the connection lines around the module. Incorrect spacing results as modules/connectionLines get stacking in the network scene. 

The Euclidean should be fine. The +6 and -8 spacings were chosen based on my visual preference. 
