### PR TITLE
Color map rescale refactor

### DIFF
--- a/src/Core/Datatypes/ColorMap.cc
+++ b/src/Core/Datatypes/ColorMap.cc
@@ -113,6 +113,11 @@ ColorRGB ColorMap::getColorMapVal(double v) const
   double f = getTransformedColor(v);
   //now grab the RGB
   ColorRGB col;
+  // This Rainbow takes into account scientific visualization recommendations.
+  // It tones down the yellow/cyan values so they don't appear to
+  // be "brighter" than the other colors. All colors "appear" to be the
+  // same brightness.
+  // Blue -> Dark Cyan -> Green -> Orange -> Red
   if (name_ == "Rainbow") {
     if (f < 0.25)
       col = ColorRGB(0., f*3., 1. - f);
@@ -123,6 +128,8 @@ ColorRGB ColorMap::getColorMapVal(double v) const
     else
       col = ColorRGB(1., 2. - 2.*f, 0.);
   }
+  //The Old Rainbow that simply transitions from blue to red 1 color at a time.
+  // Blue -> Cyan -> Green -> Yellow -> Red
   else if (name_ == "Old Rainbow") {
     if (f < 0.25)
       col = ColorRGB(0., 4.*f, 1.);
@@ -133,6 +140,9 @@ ColorRGB ColorMap::getColorMapVal(double v) const
     else
       col = ColorRGB(1., (1.-f)*4., 0.);
   }
+  // This map is designed to appear like a heat-map, where "cooler" (lower) values
+  // are darker and approach black, and "hotter" (higher) values are lighter
+  // and approach white. In between, you have the red, orange, and yellow transitions.
   else if (name_ == "Blackbody") {
     if (f < 0.333333)
       col = ColorRGB(f * 3., 0., 0.);
@@ -141,6 +151,7 @@ ColorRGB ColorMap::getColorMapVal(double v) const
     else
       col = ColorRGB(1., 1., (f - 0.6666666) * 3.);
   }
+  // A very simple black to white map with grays in between.
   else if (name_ == "Grayscale")
     col = ColorRGB(f,f,f);
   return col;

--- a/src/Core/Datatypes/ColorMap.cc
+++ b/src/Core/Datatypes/ColorMap.cc
@@ -157,13 +157,6 @@ ColorRGB ColorMap::getColorMapVal(double v) const
   return col;
 }
 
-void ColorMap::adjustColorMapForData(double min, double max) {
-    if (rescale_scale_ == 1. && rescale_shift_ == 0.) {
-        rescale_shift_ = -min;
-        rescale_scale_ = 1. / (max - min);
-    }
-}
-
 ColorRGB ColorMap::valueToColor(double scalar) const {
     return getColorMapVal(scalar);
 }

--- a/src/Core/Datatypes/ColorMap.cc
+++ b/src/Core/Datatypes/ColorMap.cc
@@ -59,40 +59,13 @@ ColorMapHandle StandardColorMapFactory::create(const std::string& name, const si
 
   return boost::make_shared<ColorMap>(name, res, shift, invert, rescale_scale, rescale_shift);
 }
-
-double ColorMap::Hue_2_RGB(double v1, double v2, double vH) 
-{
-  if (vH < 0) vH += 1.;
-  if (vH > 1) vH -= 1.;
-  if ((6 * vH) < 1) return (v1 + (v2 - v1) * 6. * vH);
-  if ((2 * vH) < 1) return (v2);
-  if ((3 * vH) < 2) return (v1 + (v2 - v1) * ((.666667) - vH) * 6.);
-  return (v1);
-}
-
-ColorRGB ColorMap::hslToRGB(double h, double s, double l) 
-{
-  double r, g, b;
-  if (s == 0.) {
-    r = g = b = l;
-  }
-  else {
-    double var_1, var_2;
-    if (l < 0.5) var_2 = l * (1. + s);
-    else           var_2 = (l + s) - (s * l);
-
-    var_1 = 2 * l - var_2;
-
-    r = Hue_2_RGB(var_1, var_2, h + (.333333));
-    g = Hue_2_RGB(var_1, var_2, h);
-    b = Hue_2_RGB(var_1, var_2, h - (.333333));
-  }
-  return ColorRGB(std::min(std::max(r, 0.), 1.),
-    std::min(std::max(g, 0.), 1.),
-    std::min(std::max(b, 0.), 1.));
-}
-
-
+/**
+ * @name getTransformedColor
+ * @brief This method transforms the raw data into ColorMap space.
+ * This includes the resolution, the gamma shift, and data rescaling (using data min/max)
+ * @param v The input value from raw data that will be transformed (usually into [0,1] space).
+ * @return The scalar double value transformed into ColorMap space from raw data.
+ */
 double ColorMap::getTransformedColor(double f) const 
 {
   /////////////////////////////////////////////////
@@ -125,50 +98,82 @@ double ColorMap::getTransformedColor(double f) const
   v = std::pow(v, (1. / denom));
   return std::min(std::max(0.,v),1.);
 }
-
+/**
+ * @name getColorMapVal
+ * @brief This method returns the RGB value for the current colormap parameters.
+ * The input comes from raw data values. To scale to data, ColorMap
+ *           must be created with those parameters. The input is transformed, then 
+ *           used to select a color from a set of color maps (currently defined by 
+ *           strings.
+ * @param v The input value from raw data that will be mapped to a color.
+ * @return The RGB value mapped from the transformed input into the ColorMap's named map.
+ */
 ColorRGB ColorMap::getColorMapVal(double v) const 
 {
   double f = getTransformedColor(v);
   //now grab the RGB
   ColorRGB col;
   if (name_ == "Rainbow") {
-    if (0. <= f && f < 0.25)
+    if (f < 0.25)
       col = ColorRGB(0., f*3., 1. - f);
     else if (0.25 <= f && f < 0.5)
       col = ColorRGB(0., f + 0.5, 1.5 - f*3.);
     else if (0.5 <= f && f < 0.75)
       col = ColorRGB(4.*f - 2., 2. - 2.*f, 0.);
-    else if (0.75 <= f && f <= 1.0)
+    else
       col = ColorRGB(1., 2. - 2.*f, 0.);
   }
   else if (name_ == "Old Rainbow") {
-    col = hslToRGB((1. - f) * 0.675, 0.95, 0.5);
+    if (f < 0.25)
+      col = ColorRGB(0., 4.*f, 1.);
+    else if (0.25 <= f && f < 0.5)
+      col = ColorRGB(0., 1., (.5 - f)*4.);
+    else if (0.5 <= f && f < 0.75)
+      col = ColorRGB((f - 0.5)*4., 1., 0.);
+    else
+      col = ColorRGB(1., (1.-f)*4., 0.);
   }
   else if (name_ == "Blackbody") {
     if (f < 0.333333)
-      col = ColorRGB(std::min(std::max(f * 3., 0.), 1.), 0., 0.);
+      col = ColorRGB(f * 3., 0., 0.);
     else if (f < 0.6666666)
-      col = ColorRGB(1., std::min(std::max((f - 0.333333) * 3., 0.), 1.), 0.);
+      col = ColorRGB(1., (f - 0.333333) * 3., 0.);
     else
-      col = ColorRGB(1., 1., std::min(std::max((f - 0.6666666) * 3., 0.), 1.));
+      col = ColorRGB(1., 1., (f - 0.6666666) * 3.);
   }
   else if (name_ == "Grayscale")
-    col = hslToRGB(0., 0., f);
+    col = ColorRGB(f,f,f);
   return col;
 }
-
+/**
+ * @name valueToColor
+ * @brief Takes a scalar value and directly passes into getColorMap.
+ * @param The raw data value as a scalar double.
+ * @return The RGB value mapped from the scalar.
+ */
 ColorRGB ColorMap::valueToColor(double scalar) const {
     return getColorMapVal(scalar);
 }
-
+/**
+ * @name valueToColor
+ * @brief Takes a tensor value and creates an RGB value.
+ * @param The raw data value as a tensor.
+ * @return The RGB value mapped from the tensor.
+ */
 ColorRGB ColorMap::valueToColor(const Tensor &tensor) const {
-    //TODO this is not implemented.
+    //TODO this is probably not implemented correctly.
     return ColorRGB(getTransformedColor(fabs(tensor.xx())),
                     getTransformedColor(fabs(tensor.yy())),
                     getTransformedColor(fabs(tensor.zz())));
 }
+/**
+ * @name valueToColor
+ * @brief Takes a vector value and creates an RGB value.
+ * @param The raw data value as a vector.
+ * @return The RGB value mapped from the vector.
+ */
 ColorRGB ColorMap::valueToColor(const Vector &vector) const {
-    //TODO is this correct?
+    //TODO this is probably not implemented correctly.
     return ColorRGB(getTransformedColor(fabs(vector.x())),
                     getTransformedColor(fabs(vector.y())),
                     getTransformedColor(fabs(vector.z())));
@@ -181,5 +186,3 @@ double ColorMap::getColorMapShift() const { return shift_; }
 bool ColorMap::getColorMapInvert() const { return invert_; }
 double ColorMap::getColorMapRescaleScale() const { return rescale_scale_; }
 double ColorMap::getColorMapRescaleShift() const { return rescale_shift_; }
-void ColorMap::setColorMapRescaleScale(double scale) { rescale_scale_ = scale; }
-void ColorMap::setColorMapRescaleShift(double shift) { rescale_shift_ = shift; }

--- a/src/Core/Datatypes/ColorMap.cc
+++ b/src/Core/Datatypes/ColorMap.cc
@@ -164,17 +164,17 @@ void ColorMap::adjustColorMapForData(double min, double max) {
     }
 }
 
-ColorRGB ColorMap::valueToColor(double scalar) {
+ColorRGB ColorMap::valueToColor(double scalar) const {
     return getColorMapVal(scalar);
 }
 
-ColorRGB ColorMap::valueToColor(Tensor tensor) {
+ColorRGB ColorMap::valueToColor(const Tensor &tensor) const {
     //TODO this is not implemented.
     return ColorRGB(getTransformedColor(fabs(tensor.xx())),
                     getTransformedColor(fabs(tensor.yy())),
                     getTransformedColor(fabs(tensor.zz())));
 }
-ColorRGB ColorMap::valueToColor(Vector vector) {
+ColorRGB ColorMap::valueToColor(const Vector &vector) const {
     //TODO is this correct?
     return ColorRGB(getTransformedColor(fabs(vector.x())),
                     getTransformedColor(fabs(vector.y())),

--- a/src/Core/Datatypes/ColorMap.cc
+++ b/src/Core/Datatypes/ColorMap.cc
@@ -32,6 +32,7 @@
 #include <iostream>
 
 using namespace SCIRun::Core::Datatypes;
+using namespace SCIRun::Core::Geometry;
 
 ColorMap::ColorMap(const std::string& name, const size_t resolution, const double shift,
   const bool invert, const double rescale_scale, const double rescale_shift,
@@ -107,7 +108,7 @@ float ColorMap::getTransformedColor(float f) const
   }
   /////////////////////////////////////////////////
 
-  const float rescaled01 = static_cast<float>(f * rescale_scale_ + rescale_shift_);
+  const float rescaled01 = static_cast<float>((f + rescale_shift_) * rescale_scale_);
 
   float v = std::min(std::max(0.f, rescaled01), 1.f);
   double shift = shift_;
@@ -159,11 +160,31 @@ ColorRGB ColorMap::getColorMapVal(float v) const
   return col;
 }
 
+ColorRGB ColorMap::valueToColor(double scalar) {
+    return getColorMapVal(scalar);
+}
+
+ColorRGB ColorMap::valueToColor(Tensor tensor) {
+    //TODO this is not implemented.
+    return ColorRGB(getTransformedColor(fabs(tensor.xx())),
+                    getTransformedColor(fabs(tensor.yy())),
+                    getTransformedColor(fabs(tensor.zz())));
+}
+ColorRGB ColorMap::valueToColor(Vector vector) {
+    //TODO is this correct?
+    return ColorRGB(getTransformedColor(fabs(vector.x())),
+                    getTransformedColor(fabs(vector.y())),
+                    getTransformedColor(fabs(vector.z())));
+
+}
+
 std::string ColorMap::getColorMapName() const { return name_; }
 size_t ColorMap::getColorMapResolution() const { return resolution_; }
 double ColorMap::getColorMapShift() const { return shift_; }
 bool ColorMap::getColorMapInvert() const { return invert_; }
 double ColorMap::getColorMapRescaleScale() const { return rescale_scale_; }
 double ColorMap::getColorMapRescaleShift() const { return rescale_shift_; }
+void ColorMap::setColorMapRescaleScale(double scale) { rescale_scale_ = scale; }
+void ColorMap::setColorMapRescaleShift(double shift) { rescale_shift_ = shift; }
 double ColorMap::getColorMapActualMin() const { return actual_min_; }
 double ColorMap::getColorMapActualMax() const { return actual_max_; }

--- a/src/Core/Datatypes/ColorMap.h
+++ b/src/Core/Datatypes/ColorMap.h
@@ -58,7 +58,6 @@ namespace Datatypes {
     Core::Datatypes::ColorRGB valueToColor(double scalar) const;
     Core::Datatypes::ColorRGB valueToColor(const Core::Geometry::Tensor &tensor) const;
     Core::Datatypes::ColorRGB valueToColor(const Core::Geometry::Vector &vector) const;
-    void adjustColorMapForData(double min, double max);
   private:
     std::string name_;
     size_t resolution_;

--- a/src/Core/Datatypes/ColorMap.h
+++ b/src/Core/Datatypes/ColorMap.h
@@ -46,6 +46,7 @@ namespace Datatypes {
     explicit ColorMap(const std::string& name = "Rainbow", const size_t resolution = 256,
                         const double shift = 0.0, const bool invert = false,
                         const double rescale_scale = 1.0, const double rescale_shift = 0.);
+      
     virtual ColorMap* clone() const;
 
     std::string getColorMapName() const;
@@ -54,23 +55,28 @@ namespace Datatypes {
     bool getColorMapInvert() const;
     double getColorMapRescaleScale() const;
     double getColorMapRescaleShift() const;
-    Core::Datatypes::ColorRGB getColorMapVal(double v) const;
+    
     Core::Datatypes::ColorRGB valueToColor(double scalar) const;
     Core::Datatypes::ColorRGB valueToColor(const Core::Geometry::Tensor &tensor) const;
     Core::Datatypes::ColorRGB valueToColor(const Core::Geometry::Vector &vector) const;
+    
   private:
-    std::string name_;
-    size_t resolution_;
-    double shift_;
-    bool invert_;
-    //rescaling options.
-    double rescale_scale_;
-    double rescale_shift_;
-    static double Hue_2_RGB(double v1, double v2, double vH);
-    static Core::Datatypes::ColorRGB hslToRGB(double h, double s, double l);
+    ///<< Internal functions.
+    Core::Datatypes::ColorRGB getColorMapVal(double v) const;
     double getTransformedColor(double v) const;
-    void setColorMapRescaleScale(double scale);
-    void setColorMapRescaleShift(double shift);
+    
+    ///<< The colormap's name.
+    std::string name_;
+    ///<< The resolution of the map [2,256].
+    size_t resolution_;
+    ///<< The gamma shift.
+    double shift_;
+    ///<< Whether to invert the map or not.
+    bool invert_;
+    ///<< Rescaling scale (usually 1. / (data_max - data_min) ).
+    double rescale_scale_;
+    ///<< Rescaling shift (usually -data_min). Shift happens before scale.
+    double rescale_shift_;
   };
 
   class SCISHARE StandardColorMapFactory : boost::noncopyable

--- a/src/Core/Datatypes/ColorMap.h
+++ b/src/Core/Datatypes/ColorMap.h
@@ -45,8 +45,7 @@ namespace Datatypes {
   public:
     explicit ColorMap(const std::string& name, const size_t resolution = 256,
                         const double shift = 0.0, const bool invert = false,
-                        const double rescale_scale = 1.0, const double rescale_shift = 0.,
-                        const double actual_min = 0., const double actual_max = 1.);
+                        const double rescale_scale = 1.0, const double rescale_shift = 0.);
     virtual ColorMap* clone() const;
 
     std::string getColorMapName() const;
@@ -55,14 +54,11 @@ namespace Datatypes {
     bool getColorMapInvert() const;
     double getColorMapRescaleScale() const;
     double getColorMapRescaleShift() const;
-    void setColorMapRescaleScale(double scale);
-    void setColorMapRescaleShift(double shift);
-    double getColorMapActualMin() const;
-    double getColorMapActualMax() const;
-    Core::Datatypes::ColorRGB getColorMapVal(float v) const;
+    Core::Datatypes::ColorRGB getColorMapVal(double v) const;
     Core::Datatypes::ColorRGB valueToColor(double scalar);
     Core::Datatypes::ColorRGB valueToColor(Core::Geometry::Tensor tensor);
     Core::Datatypes::ColorRGB valueToColor(Core::Geometry::Vector vector);
+    void adjustColorMapForData(double min, double max);
   private:
     std::string name_;
     size_t resolution_;
@@ -71,11 +67,11 @@ namespace Datatypes {
     //rescaling options.
     double rescale_scale_;
     double rescale_shift_;
-    double actual_min_;
-    double actual_max_;
-    static float Hue_2_RGB(float v1, float v2, float vH);
-    static Core::Datatypes::ColorRGB hslToRGB(float h, float s, float l);
-    float getTransformedColor(float v) const;
+    static double Hue_2_RGB(double v1, double v2, double vH);
+    static Core::Datatypes::ColorRGB hslToRGB(double h, double s, double l);
+    double getTransformedColor(double v) const;
+    void setColorMapRescaleScale(double scale);
+    void setColorMapRescaleShift(double shift);
   };
 
   class SCISHARE StandardColorMapFactory : boost::noncopyable
@@ -83,8 +79,7 @@ namespace Datatypes {
   public:
     static ColorMapHandle create(const std::string& name, const size_t &resolution,
                                     const double &shift, const bool &invert,
-                                    const double &rescale_scale, const double &rescale_shift,
-                                    const double &actual_min, const double &actual_max);
+                                    const double &rescale_scale, const double &rescale_shift);
   private:
     StandardColorMapFactory();
   };

--- a/src/Core/Datatypes/ColorMap.h
+++ b/src/Core/Datatypes/ColorMap.h
@@ -43,7 +43,7 @@ namespace Datatypes {
   class SCISHARE ColorMap : public Datatype
   {
   public:
-    explicit ColorMap(const std::string& name, const size_t resolution = 256,
+    explicit ColorMap(const std::string& name = "Rainbow", const size_t resolution = 256,
                         const double shift = 0.0, const bool invert = false,
                         const double rescale_scale = 1.0, const double rescale_shift = 0.);
     virtual ColorMap* clone() const;
@@ -55,9 +55,9 @@ namespace Datatypes {
     double getColorMapRescaleScale() const;
     double getColorMapRescaleShift() const;
     Core::Datatypes::ColorRGB getColorMapVal(double v) const;
-    Core::Datatypes::ColorRGB valueToColor(double scalar);
-    Core::Datatypes::ColorRGB valueToColor(Core::Geometry::Tensor tensor);
-    Core::Datatypes::ColorRGB valueToColor(Core::Geometry::Vector vector);
+    Core::Datatypes::ColorRGB valueToColor(double scalar) const;
+    Core::Datatypes::ColorRGB valueToColor(const Core::Geometry::Tensor &tensor) const;
+    Core::Datatypes::ColorRGB valueToColor(const Core::Geometry::Vector &vector) const;
     void adjustColorMapForData(double min, double max);
   private:
     std::string name_;

--- a/src/Core/Datatypes/ColorMap.h
+++ b/src/Core/Datatypes/ColorMap.h
@@ -43,9 +43,11 @@ namespace Datatypes {
   class SCISHARE ColorMap : public Datatype
   {
   public:
+    // Because colors need to be in the range [0,1], and SCIRun4 used [-1,1] for it's
+    // default input range, we need to transform by default the data into [0,1] range.
     explicit ColorMap(const std::string& name = "Rainbow", const size_t resolution = 256,
                         const double shift = 0.0, const bool invert = false,
-                        const double rescale_scale = 1.0, const double rescale_shift = 0.);
+                        const double rescale_scale = .5, const double rescale_shift = 1.);
       
     virtual ColorMap* clone() const;
 
@@ -82,9 +84,10 @@ namespace Datatypes {
   class SCISHARE StandardColorMapFactory : boost::noncopyable
   {
   public:
-    static ColorMapHandle create(const std::string& name, const size_t &resolution,
-                                    const double &shift, const bool &invert,
-                                    const double &rescale_scale, const double &rescale_shift);
+   // See explanation for defaults above in ColorMap Constructor
+    static ColorMapHandle create(const std::string& name = "Rainbow", const size_t &resolution = 256,
+                                    const double &shift = 0.0, const bool &invert = false,
+                                    const double &rescale_scale = .5, const double &rescale_shift = 1.);
   private:
     StandardColorMapFactory();
   };

--- a/src/Core/Datatypes/ColorMap.h
+++ b/src/Core/Datatypes/ColorMap.h
@@ -32,6 +32,8 @@
 #include <Core/Datatypes/Datatype.h>
 #include <boost/noncopyable.hpp>
 #include <Core/Datatypes/Color.h>
+#include <Core/GeometryPrimitives/Vector.h>
+#include <Core/GeometryPrimitives/Tensor.h>
 #include <Core/Datatypes/share.h>
 
 namespace SCIRun {
@@ -53,10 +55,14 @@ namespace Datatypes {
     bool getColorMapInvert() const;
     double getColorMapRescaleScale() const;
     double getColorMapRescaleShift() const;
+    void setColorMapRescaleScale(double scale);
+    void setColorMapRescaleShift(double shift);
     double getColorMapActualMin() const;
     double getColorMapActualMax() const;
     Core::Datatypes::ColorRGB getColorMapVal(float v) const;
-    float getTransformedColor(float v) const;
+    Core::Datatypes::ColorRGB valueToColor(double scalar);
+    Core::Datatypes::ColorRGB valueToColor(Core::Geometry::Tensor tensor);
+    Core::Datatypes::ColorRGB valueToColor(Core::Geometry::Vector vector);
   private:
     std::string name_;
     size_t resolution_;
@@ -69,6 +75,7 @@ namespace Datatypes {
     double actual_max_;
     static float Hue_2_RGB(float v1, float v2, float vH);
     static Core::Datatypes::ColorRGB hslToRGB(float h, float s, float l);
+    float getTransformedColor(float v) const;
   };
 
   class SCISHARE StandardColorMapFactory : boost::noncopyable

--- a/src/Interface/Modules/Render/ES/SRInterface.h
+++ b/src/Interface/Modules/Render/ES/SRInterface.h
@@ -258,12 +258,6 @@ namespace SCIRun {
 			size_t                            mScreenWidth;     ///< Screen width in pixels.
 			size_t                            mScreenHeight;    ///< Screen height in pixels.
 
-
-			GLuint                            mRainbowCMap;     ///< Rainbow color map.
-			GLuint                            mOldRainbowCMap;     ///< Rainbow color map.
-			GLuint                            mGrayscaleCMap;   ///< Grayscale color map.
-			GLuint                            mBlackBodyCMap;   ///< Blackbody color map.
-
             int axesFailCount_;
 			std::shared_ptr<Gui::GLContext>   mContext;         ///< Context to use for rendering.
 			std::unique_ptr<SRCamera>         mCamera;          ///< Primary camera.

--- a/src/Interface/Modules/Render/ES/shaders/ColorMap.fs
+++ b/src/Interface/Modules/Render/ES/shaders/ColorMap.fs
@@ -25,42 +25,12 @@
    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
    DEALINGS IN THE SOFTWARE.
  */
-#ifdef OPENGL_ES
-#ifdef GL_FRAGMENT_PRECISION_HIGH
-// Default precision
-precision highp float;
-#else
-precision mediump float;
-#endif
-#endif
-
-uniform sampler1D uTX0;
-uniform float   uCMInvert;
-uniform float   uCMShift;
-uniform float   uCMResolution;
-uniform float   uRescaleScale;
-uniform float   uRescaleShift;
-varying float   fFieldData;
+varying vec4   fColor;
 
 // Transparency to use along side the color map.
 uniform float uTransparency;
 
 void main()
 {
-   float param = clamp((fFieldData + uRescaleShift) * uRescaleScale,0.,1.);
-   float shift = uCMShift;
-   if (uCMInvert != 0.) {
-      param = 1. - param;
-      shift = shift * -1.;
-   }
-   //apply the resolution
-   int res = int(uCMResolution);
-   param = float(int(param * (float(res)))) / float(res - 1);
-   // the shift is a gamma.
-   float bp = 1. / tan((3.14159265359 / 2.) *  ( 0.5 - shift * 0.5));
-   param = pow(param,bp);
-
-   vec4 color = texture1D( uTX0, param );
-   color.a       = uTransparency;
-   gl_FragColor  = color;
+   gl_FragColor  = vec4(fColor.xyz,uTransparency);
 }

--- a/src/Interface/Modules/Render/ES/shaders/ColorMap.fs
+++ b/src/Interface/Modules/Render/ES/shaders/ColorMap.fs
@@ -40,14 +40,14 @@ uniform float   uCMShift;
 uniform float   uCMResolution;
 uniform float   uRescaleScale;
 uniform float   uRescaleShift;
-varying float  fFieldData;
+varying float   fFieldData;
 
 // Transparency to use along side the color map.
 uniform float uTransparency;
 
 void main()
 {
-   float param = clamp(fFieldData * uRescaleScale + uRescaleShift,0.,1.);
+   float param = clamp((fFieldData + uRescaleShift) * uRescaleScale,0.,1.);
    float shift = uCMShift;
    if (uCMInvert != 0.) {
       param = 1. - param;

--- a/src/Interface/Modules/Render/ES/shaders/ColorMap.vs
+++ b/src/Interface/Modules/Render/ES/shaders/ColorMap.vs
@@ -29,18 +29,15 @@
 // Uniforms
 uniform mat4  uProjIVObject;      // Projection * Inverse View * World XForm
 
-// Transparency to use along side the color map.
-
 // Attributes
 attribute vec3  aPos;
-attribute float aFieldData;
+attribute vec4  aColor;
 
 // Outputs to the fragment shader.
-varying float    fFieldData;
+varying vec4    fColor;
 
 void main( void )
 {
   gl_Position = uProjIVObject * vec4(aPos, 1.0);
-  //fFieldData  = aFieldData;
-  fFieldData  = aFieldData;
+  fColor  = aColor;
 }

--- a/src/Interface/Modules/Render/ES/shaders/ColorMap.vs
+++ b/src/Interface/Modules/Render/ES/shaders/ColorMap.vs
@@ -29,10 +29,6 @@
 // Uniforms
 uniform mat4  uProjIVObject;      // Projection * Inverse View * World XForm
 
-// The following values are used to rescale the data between 0 .. 1.
-uniform float uMinVal;
-uniform float uMaxVal;
-
 // Transparency to use along side the color map.
 
 // Attributes
@@ -46,5 +42,5 @@ void main( void )
 {
   gl_Position = uProjIVObject * vec4(aPos, 1.0);
   //fFieldData  = aFieldData;
-  fFieldData  = (aFieldData - uMinVal) / (uMaxVal - uMinVal);
+  fFieldData  = aFieldData;
 }

--- a/src/Interface/Modules/Render/ES/shaders/ColorMapLegend.fs
+++ b/src/Interface/Modules/Render/ES/shaders/ColorMapLegend.fs
@@ -36,7 +36,7 @@ precision mediump float;
 
 uniform sampler1D uTX0;
 
-varying float vFieldData;
+varying float   vFieldData;
 uniform float   uCMInvert;
 uniform float   uCMShift;
 uniform float   uCMResolution;

--- a/src/Interface/Modules/Render/ES/shaders/ColorMapLegend.fs
+++ b/src/Interface/Modules/Render/ES/shaders/ColorMapLegend.fs
@@ -25,38 +25,10 @@
    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
    DEALINGS IN THE SOFTWARE.
  */
-#ifdef OPENGL_ES
-#ifdef GL_FRAGMENT_PRECISION_HIGH
-// Default precision
-precision highp float;
-#else
-precision mediump float;
-#endif
-#endif
 
-uniform sampler1D uTX0;
-
-varying float   vFieldData;
-uniform float   uCMInvert;
-uniform float   uCMShift;
-uniform float   uCMResolution;
-
+varying vec4 fColor;
+ 
 void main()
 {
-   float param = vFieldData;
-   float shift = uCMShift;
-   if (uCMInvert != 0.) {
-      param = 1. - param;
-      shift = shift * -1.;
-   }
-   //apply the resolution
-   int res = int(uCMResolution);
-   param = float(int(param * (float(res)))) / float(res - 1);
-   // the shift is a gamma.
-   float bp = 1. / tan((3.14159265359 / 2.) *  ( 0.5 - shift * 0.5));
-   param = pow(param,bp);
-
-   vec4 color = texture1D( uTX0, param );
-   color.a       = 1.0;
-   gl_FragColor = color;
+   gl_FragColor = fColor;
 }

--- a/src/Interface/Modules/Render/ES/shaders/ColorMapLegend.vs
+++ b/src/Interface/Modules/Render/ES/shaders/ColorMapLegend.vs
@@ -35,10 +35,10 @@ uniform float    uDisplayLength;
 
 // Attributes
 attribute vec3  aPos;
-attribute float aFieldData;
+attribute vec4  aColor;
 
 // Outputs to the fragment shader.
-varying float   vFieldData;
+varying vec4   fColor;
 
 void main( void )
 {
@@ -56,5 +56,5 @@ void main( void )
                   -1.):(ex?0.05:0.1)));
   gl_Position = vec4(newPos.x * x_scale + x_trans, 
                      newPos.y * y_scale + y_trans, newPos.z, 1.0);
-  vFieldData  = aFieldData;
+  fColor = aColor;
 }

--- a/src/Interface/Modules/Render/ES/shaders/ColorMapUniform.fs
+++ b/src/Interface/Modules/Render/ES/shaders/ColorMapUniform.fs
@@ -44,5 +44,5 @@ void main()
 {
   vec4 color    = texture1D(uTX0, fFieldData);
   color.a       = uTransparency;
-	gl_FragColor  = color;
+  gl_FragColor  = color;
 }

--- a/src/Interface/Modules/Render/ES/shaders/ColorMapUniform.vs
+++ b/src/Interface/Modules/Render/ES/shaders/ColorMapUniform.vs
@@ -30,8 +30,6 @@
 uniform mat4  uProjIVObject;      // Projection * Inverse View * World XForm
 
 // The following values are used to rescale the data between 0 .. 1.
-uniform float uMinVal;
-uniform float uMaxVal;
 uniform float uFieldData;
 
 // Transparency to use along side the color map.
@@ -45,5 +43,5 @@ varying float    fFieldData;
 void main( void )
 {
   gl_Position = uProjIVObject * vec4(aPos, 1.0);
-  fFieldData  = (uFieldData - uMinVal) / (uMaxVal - uMinVal);
+  fFieldData  = uFieldData;
 }

--- a/src/Interface/Modules/Render/ES/shaders/DblSided_ColorMap.fs
+++ b/src/Interface/Modules/Render/ES/shaders/DblSided_ColorMap.fs
@@ -25,24 +25,12 @@
    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
    DEALINGS IN THE SOFTWARE.
 */
-#ifdef OPENGL_ES
-  #ifdef GL_FRAGMENT_PRECISION_HIGH
-    // Default precision
-    precision highp float;
-  #else
-    precision mediump float;
-  #endif
-#endif
-
-uniform sampler1D uTX0;
-varying float	fFieldData;
+varying vec4 fColor;
 
 // Transparency to use along side the color map.
 uniform float uTransparency;
 
 void main()
 {
-  vec4 color    = texture1D(uTX0, fFieldData);
-  color.a       = uTransparency;
-  gl_FragColor  = color;
+  gl_FragColor  = vec4(fColor.xyx,uTransparency);
 }

--- a/src/Interface/Modules/Render/ES/shaders/DblSided_ColorMap.fs
+++ b/src/Interface/Modules/Render/ES/shaders/DblSided_ColorMap.fs
@@ -44,5 +44,5 @@ void main()
 {
   vec4 color    = texture1D(uTX0, fFieldData);
   color.a       = uTransparency;
-	gl_FragColor  = color;
+  gl_FragColor  = color;
 }

--- a/src/Interface/Modules/Render/ES/shaders/DblSided_ColorMap.vs
+++ b/src/Interface/Modules/Render/ES/shaders/DblSided_ColorMap.vs
@@ -33,15 +33,15 @@ uniform float   uFDToggle;        // Field data toggle
 
 // Attributes
 attribute vec3  aPos;
-attribute float aFieldData;
-attribute float aFieldDataSecondary;
+attribute vec4  aColor;
+attribute vec4  aColorSecondary;
 
 // Outputs to the fragment shader.
-varying float    fFieldData;
+varying vec4    fColor;
 
 void main( void )
 {
   gl_Position = uProjIVObject * vec4(aPos, 1.0);
-  float fieldData = uFDToggle * aFieldData + (1.0 - uFDToggle) * aFieldDataSecondary;
-  fFieldData  = fieldData;
+  vec4 colorData = uFDToggle * aColor + (1.0 - uFDToggle) * aColorSecondary;
+  fColor  = colorData;
 }

--- a/src/Interface/Modules/Render/ES/shaders/DblSided_ColorMap.vs
+++ b/src/Interface/Modules/Render/ES/shaders/DblSided_ColorMap.vs
@@ -29,8 +29,6 @@
 // Uniforms
 uniform mat4    uProjIVObject;    // Projection * Inverse View * World XForm
 uniform vec4    uColor;           // Uniform color
-uniform float   uMinVal;
-uniform float   uMaxVal;
 uniform float   uFDToggle;        // Field data toggle
 
 // Attributes
@@ -45,5 +43,5 @@ void main( void )
 {
   gl_Position = uProjIVObject * vec4(aPos, 1.0);
   float fieldData = uFDToggle * aFieldData + (1.0 - uFDToggle) * aFieldDataSecondary;
-  fFieldData  = (fieldData - uMinVal) / (uMaxVal - uMinVal);
+  fFieldData  = fieldData;
 }

--- a/src/Interface/Modules/Render/ES/shaders/DblSided_DirPhongCMap.fs
+++ b/src/Interface/Modules/Render/ES/shaders/DblSided_DirPhongCMap.fs
@@ -25,14 +25,6 @@
    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
    DEALINGS IN THE SOFTWARE.
 */
-#ifdef OPENGL_ES
-  #ifdef GL_FRAGMENT_PRECISION_HIGH
-    // Default precision
-    precision highp float;
-  #else
-    precision mediump float;
-  #endif
-#endif
 
 uniform vec3    uCamViewVec;        // Camera 'at' vector in world space
 uniform vec4    uAmbientColor;      // Ambient color
@@ -40,13 +32,12 @@ uniform vec4    uSpecularColor;     // Specular color
 uniform vec4    uDiffuseColor;      // Diffuse color
 uniform float   uSpecularPower;     // Specular power
 uniform vec3    uLightDirWorld;     // Directional light (world space).
-uniform sampler1D uTX0;
 
 // Lighting in world space. Generally, it's better to light in eye space if you
 // are dealing with point lights. Since we are only dealing with directional
 // lights we light in world space.
 varying vec3  vNormal;
-varying float vFieldData;
+varying vec4  vColor;
 
 void main()
 {
@@ -71,7 +62,7 @@ void main()
   vec3  reflection  = reflect(invLightDir, normal);
   float spec        = max(0.0, dot(reflection, uCamViewVec));
 
-  vec4 diffuseColor = texture1D( uTX0, vFieldData );
+  vec4 diffuseColor = vColor;
   diffuseColor.a = uAmbientColor.a;
 
   spec              = pow(spec, uSpecularPower);

--- a/src/Interface/Modules/Render/ES/shaders/DblSided_DirPhongCMap.vs
+++ b/src/Interface/Modules/Render/ES/shaders/DblSided_DirPhongCMap.vs
@@ -29,19 +29,17 @@
 // Uniforms
 uniform mat4    uProjIVObject;      // Projection transform * Inverse View
 uniform mat4    uObject;            // Object -> World
-uniform float   uMinVal;
-uniform float   uMaxVal;
 uniform float   uFDToggle;          // Field data toggle
 
 // Attributes
 attribute vec3  aPos;
 attribute vec3  aNormal;
-attribute float aFieldData;
-attribute float aFieldDataSecondary;
+attribute vec4  aColor;
+attribute vec4  aColorSecondary;
 
 // Outputs to the fragment shader.
 varying vec3    vNormal;
-varying float   vFieldData;
+varying vec4    vColor;
 
 void main( void )
 {
@@ -49,6 +47,6 @@ void main( void )
 
   vNormal  = vec3(uObject * vec4(aNormal, 0.0));
 
-  float fieldData = uFDToggle * aFieldData + (1.0 - uFDToggle) * aFieldDataSecondary;
-  vFieldData  = (fieldData - uMinVal) / (uMaxVal - uMinVal);
+  vec4 colorData = uFDToggle * aColor + (1.0 - uFDToggle) * aColorSecondary;
+  vColor = colorData;
 }

--- a/src/Interface/Modules/Render/ES/shaders/DirPhong.fs
+++ b/src/Interface/Modules/Render/ES/shaders/DirPhong.fs
@@ -40,6 +40,7 @@ uniform vec4    uDiffuseColor;      // Diffuse color
 uniform vec4    uSpecularColor;     // Specular color     
 uniform float   uSpecularPower;     // Specular power
 uniform vec3    uLightDirWorld;     // Directional light (world space).
+uniform float   uTransparency;
 
 // Lighting in world space. Generally, it's better to light in eye space if you
 // are dealing with point lights. Since we are only dealing with directional
@@ -70,6 +71,7 @@ void main()
   float spec        = max(0.0, dot(reflection, uCamViewVec));
 
   spec              = pow(spec, uSpecularPower);
-  gl_FragColor      = vec4((diffuse * spec * uSpecularColor + diffuse * uDiffuseColor + uAmbientColor).rgb, uDiffuseColor.a);
+  gl_FragColor      = vec4((diffuse * spec * uSpecularColor + 
+                       diffuse * uDiffuseColor + uAmbientColor).rgb, uTransparency);
 }
 

--- a/src/Interface/Modules/Render/ES/shaders/DirPhongCMap.fs
+++ b/src/Interface/Modules/Render/ES/shaders/DirPhongCMap.fs
@@ -25,14 +25,6 @@
    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
    DEALINGS IN THE SOFTWARE.
  */
-#ifdef OPENGL_ES
-#ifdef GL_FRAGMENT_PRECISION_HIGH
-// Default precision
-precision highp float;
-#else
-precision mediump float;
-#endif
-#endif
 
 uniform vec3    uCamViewVec;        // Camera 'at' vector in world space
 uniform vec4    uAmbientColor;      // Ambient color
@@ -41,18 +33,10 @@ uniform vec4    uDiffuseColor;      // Diffuse color
 uniform float   uSpecularPower;     // Specular power
 uniform vec3    uLightDirWorld;     // Directional light (world space).
 uniform float   uTransparency;
-uniform sampler1D uTX0;
-uniform float   uCMInvert;
-uniform float   uCMShift;
-uniform float   uCMResolution;
-uniform float   uRescaleScale;
-uniform float   uRescaleShift;
-
-// Lighting in world space. Generally, it's better to light in eye space if you
 // are dealing with point lights. Since we are only dealing with directional
 // lights we light in world space.
 varying vec3  vNormal;
-varying float vFieldData;
+varying vec4  vColor; 
 
 void main()
 {
@@ -77,20 +61,7 @@ void main()
    vec3  reflection  = reflect(invLightDir, normal);
    float spec        = max(0.0, dot(reflection, uCamViewVec));
 
-   float param = clamp((vFieldData + uRescaleShift) * uRescaleScale,0.,1.);
-   float shift = uCMShift;
-   if (uCMInvert != 0.) {
-      param = 1. - param;
-      shift = shift * -1.;
-   }
-   //apply the resolution
-   int res = int(uCMResolution);
-   param = float(int(param * (float(res)))) / float(res - 1);
-   // the shift is a gamma.
-   float bp = 1. / tan((3.14159265359 / 2.) *  ( 0.5 - shift * 0.5));
-   param = pow(param,bp);
-
-   vec4 diffuseColor = texture1D( uTX0, param );
+   vec4 diffuseColor = vColor;
 
    spec              = pow(spec, uSpecularPower);
    gl_FragColor      = vec4((diffuse * spec * uSpecularColor + diffuse * diffuseColor + uAmbientColor).rgb, uTransparency);

--- a/src/Interface/Modules/Render/ES/shaders/DirPhongCMap.fs
+++ b/src/Interface/Modules/Render/ES/shaders/DirPhongCMap.fs
@@ -77,7 +77,7 @@ void main()
    vec3  reflection  = reflect(invLightDir, normal);
    float spec        = max(0.0, dot(reflection, uCamViewVec));
 
-   float param = clamp(vFieldData * uRescaleScale + uRescaleShift,0.,1.);
+   float param = clamp((vFieldData + uRescaleShift) * uRescaleScale,0.,1.);
    float shift = uCMShift;
    if (uCMInvert != 0.) {
       param = 1. - param;

--- a/src/Interface/Modules/Render/ES/shaders/DirPhongCMap.vs
+++ b/src/Interface/Modules/Render/ES/shaders/DirPhongCMap.vs
@@ -29,8 +29,6 @@
 // Uniforms
 uniform mat4    uProjIVObject;      // Projection transform * Inverse View
 uniform mat4    uObject;            // Object -> World
-uniform float   uMinVal;
-uniform float   uMaxVal;
 
 // Attributes
 attribute vec3  aPos;
@@ -46,6 +44,6 @@ void main( void )
    // Todo: Add gamma correction factor of 2.2. For textures, we assume that it
    // was generated in gamma space, and we need to convert it to linear space.
    vNormal  = vec3(uObject * vec4(aNormal, 0.0));
-   vFieldData = (aFieldData - uMinVal) / (uMaxVal - uMinVal);
+   vFieldData = aFieldData;
    gl_Position = uProjIVObject * vec4(aPos, 1.0);
 }

--- a/src/Interface/Modules/Render/ES/shaders/DirPhongCMap.vs
+++ b/src/Interface/Modules/Render/ES/shaders/DirPhongCMap.vs
@@ -33,17 +33,17 @@ uniform mat4    uObject;            // Object -> World
 // Attributes
 attribute vec3  aPos;
 attribute vec3  aNormal;
-attribute float aFieldData;
+attribute vec4  aColor;
 
 // Outputs to the fragment shader.
 varying vec3    vNormal;
-varying float   vFieldData;
+varying vec4    vColor;
 
 void main( void )
 {
    // Todo: Add gamma correction factor of 2.2. For textures, we assume that it
    // was generated in gamma space, and we need to convert it to linear space.
    vNormal  = vec3(uObject * vec4(aNormal, 0.0));
-   vFieldData = aFieldData;
+   vColor = aColor;
    gl_Position = uProjIVObject * vec4(aPos, 1.0);
 }

--- a/src/Interface/Modules/Render/ES/shaders/DirPhongCMapUniform.fs
+++ b/src/Interface/Modules/Render/ES/shaders/DirPhongCMapUniform.fs
@@ -25,14 +25,6 @@
    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
    DEALINGS IN THE SOFTWARE.
 */
-#ifdef OPENGL_ES
-  #ifdef GL_FRAGMENT_PRECISION_HIGH
-    // Default precision
-    precision highp float;
-  #else
-    precision mediump float;
-  #endif
-#endif
 
 uniform vec3    uCamViewVec;        // Camera 'at' vector in world space
 uniform vec4    uAmbientColor;      // Ambient color
@@ -40,13 +32,12 @@ uniform vec4    uSpecularColor;     // Specular color
 uniform float   uSpecularPower;     // Specular power
 uniform vec3    uLightDirWorld;     // Directional light (world space).
 uniform float   uTransparency;
-uniform sampler1D uTX0;
 
 // Lighting in world space. Generally, it's better to light in eye space if you
 // are dealing with point lights. Since we are only dealing with directional
 // lights we light in world space.
 varying vec3  vNormal;
-varying float vFieldData;
+varying vec4  vColor;
 
 void main()
 {
@@ -71,7 +62,7 @@ void main()
   vec3  reflection  = reflect(invLightDir, normal);
   float spec        = max(0.0, dot(reflection, uCamViewVec));
 
-  vec4 diffuseColor = texture1D( uTX0, vFieldData );
+  vec4 diffuseColor = vColor;
 
   spec              = pow(spec, uSpecularPower);
   gl_FragColor      = vec4(diffuse * spec * uSpecularColor + diffuse * diffuseColor + uAmbientColor).rgb, uTransparency);

--- a/src/Interface/Modules/Render/ES/shaders/DirPhongCMapUniform.fs
+++ b/src/Interface/Modules/Render/ES/shaders/DirPhongCMapUniform.fs
@@ -72,7 +72,6 @@ void main()
   float spec        = max(0.0, dot(reflection, uCamViewVec));
 
   vec4 diffuseColor = texture1D( uTX0, vFieldData );
-  //diffuseColor.a    = uTransparency;
 
   spec              = pow(spec, uSpecularPower);
   gl_FragColor      = vec4(diffuse * spec * uSpecularColor + diffuse * diffuseColor + uAmbientColor).rgb, uTransparency);

--- a/src/Interface/Modules/Render/ES/shaders/DirPhongCMapUniform.vs
+++ b/src/Interface/Modules/Render/ES/shaders/DirPhongCMapUniform.vs
@@ -29,9 +29,6 @@
 // Uniforms
 uniform mat4    uProjIVObject;      // Projection transform * Inverse View
 uniform mat4    uObject;            // Object -> World
-
-uniform float   uMinVal;
-uniform float   uMaxVal;
 uniform float   uFieldData;
 
 // Attributes
@@ -47,6 +44,6 @@ void main( void )
   // Todo: Add gamma correction factor of 2.2. For textures, we assume that it
   // was generated in gamma space, and we need to convert it to linear space.
   vNormal  = vec3(uObject * vec4(aNormal, 0.0));
-  vFieldData  = (uFieldData - uMinVal) / (uMaxVal - uMinVal);
+  vFieldData  = uFieldData;
   gl_Position = uProjIVObject * vec4(aPos, 1.0);
 }

--- a/src/Interface/Modules/Render/ES/shaders/DirPhongCMapUniform.vs
+++ b/src/Interface/Modules/Render/ES/shaders/DirPhongCMapUniform.vs
@@ -29,7 +29,7 @@
 // Uniforms
 uniform mat4    uProjIVObject;      // Projection transform * Inverse View
 uniform mat4    uObject;            // Object -> World
-uniform float   uFieldData;
+uniform vec4   uColor;
 
 // Attributes
 attribute vec3  aPos;
@@ -37,13 +37,13 @@ attribute vec3  aNormal;
 
 // Outputs to the fragment shader.
 varying vec3    vNormal;
-varying float   vFieldData;
+varying vec4    vColor;
 
 void main( void )
 {
   // Todo: Add gamma correction factor of 2.2. For textures, we assume that it
   // was generated in gamma space, and we need to convert it to linear space.
   vNormal  = vec3(uObject * vec4(aNormal, 0.0));
-  vFieldData  = uFieldData;
+  vColor  = uColor;
   gl_Position = uProjIVObject * vec4(aPos, 1.0);
 }

--- a/src/Interface/Modules/Render/ES/systems/RenderColorMapSys.cc
+++ b/src/Interface/Modules/Render/ES/systems/RenderColorMapSys.cc
@@ -212,7 +212,7 @@ public:
       GLint uniformColorLoc = 0;
       for (const ren::VecUniform& unif : vecUniforms)
       {
-        if (std::string(unif.uniformName) == "uFieldData")
+        if (std::string(unif.uniformName) == "uColor")
         {
           uniformColorLoc = unif.uniformLocation;
         }
@@ -243,7 +243,7 @@ public:
           if (stride != 0) {posDeserialize.readBytes(stride);}
           posSize = attrib.sizeInBytes;
         }
-        else if (attrib.name == "aFieldData")
+        else if (attrib.name == "aColor")
         {
           if (stride != 0) {dataDeserialize.readBytes(stride);}
           dataSize = attrib.sizeInBytes;

--- a/src/Interface/Modules/Visualization/CreateStandardColorMapDialog.cc
+++ b/src/Interface/Modules/Visualization/CreateStandardColorMapDialog.cc
@@ -90,7 +90,7 @@ const QString CreateStandardColorMapDialog::buildGradientString(const ColorMap& 
   for (double i = 0.001; i < 1.0; i += 0.001) {
     ss << " stop:" << i;
     ss << " rgba(";
-    ColorRGB c = cm.getColorMapVal(i);
+    ColorRGB c = cm.valueToColor(i);
     ss << int(255.*c.r()) << ", " << int(255.*c.g()) << ", " << int(255.*c.b()) << ", 255),";
   }
   ss << ");";

--- a/src/Interface/Modules/Visualization/CreateStandardColorMapDialog.cc
+++ b/src/Interface/Modules/Visualization/CreateStandardColorMapDialog.cc
@@ -87,10 +87,10 @@ const QString CreateStandardColorMapDialog::buildGradientString(const ColorMap& 
   //TODO: cache these values, GUI is slow to update.
   std::stringstream ss;
   ss << "background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:0,";
-  for (double i = 0.001; i < 1.0; i += 0.001) {
+  for (double i = 0.001; i < 1.0; i += 0.001) { //styling values need to be in the range [0,1]
     ss << " stop:" << i;
     ss << " rgba(";
-    ColorRGB c = cm.valueToColor(i);
+    ColorRGB c = cm.valueToColor(i * 2. - 1.); //need to match default ColorMap data range [-1,1]
     ss << int(255.*c.r()) << ", " << int(255.*c.g()) << ", " << int(255.*c.b()) << ", 255),";
   }
   ss << ");";

--- a/src/Interface/Modules/Visualization/RescaleColorMap.ui
+++ b/src/Interface/Modules/Visualization/RescaleColorMap.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>315</width>
-    <height>107</height>
+    <width>389</width>
+    <height>136</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -18,8 +18,8 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>315</width>
-    <height>107</height>
+    <width>389</width>
+    <height>136</height>
    </size>
   </property>
   <property name="maximumSize">

--- a/src/Modules/Visualization/CreateStandardColorMap.cc
+++ b/src/Modules/Visualization/CreateStandardColorMap.cc
@@ -64,7 +64,7 @@ void CreateStandardColorMap::execute()
     //just in case there is a problem with the QT values...
     res = std::min(std::max(res,2),256);
     shift = std::min(std::max(shift,-1.),1.);
-    sendOutput(ColorMapObject, StandardColorMapFactory::create(name,res, shift,inv,1.,0.,0.,1.));
+    sendOutput(ColorMapObject, StandardColorMapFactory::create(name,res, shift,inv,1.,0.));
   }
 }
 

--- a/src/Modules/Visualization/CreateStandardColorMap.cc
+++ b/src/Modules/Visualization/CreateStandardColorMap.cc
@@ -64,7 +64,7 @@ void CreateStandardColorMap::execute()
     //just in case there is a problem with the QT values...
     res = std::min(std::max(res,2),256);
     shift = std::min(std::max(shift,-1.),1.);
-    sendOutput(ColorMapObject, StandardColorMapFactory::create(name,res, shift,inv,1.,0.));
+    sendOutput(ColorMapObject, StandardColorMapFactory::create(name,res, shift,inv));
   }
 }
 

--- a/src/Modules/Visualization/RescaleColorMap.cc
+++ b/src/Modules/Visualization/RescaleColorMap.cc
@@ -106,7 +106,7 @@ void RescaleColorMap::execute()
       colorMap->getColorMapResolution(),
       colorMap->getColorMapShift(),
       colorMap->getColorMapInvert(),
-      cm_scale, cm_shift, fixed_min, fixed_max));
+      cm_scale, cm_shift));
   }
 }
 

--- a/src/Modules/Visualization/RescaleColorMap.cc
+++ b/src/Modules/Visualization/RescaleColorMap.cc
@@ -54,7 +54,15 @@ void RescaleColorMap::setStateDefaults()
   state->setValue(Parameters::FixedMin, 0.0);
   state->setValue(Parameters::FixedMax, 1.0);
 }
-
+/**
+ * @name execute
+ *
+ * @brief This module has a simple algorithm to ensure the field data scales into ColorMap space.
+ *
+ * The "input" for this algorithm/module is the field data and the color map from
+ *  CreateStandardColorMap module. The "output" is a new color map that applies the rescaling
+ *  options from this module: rescale_shift, and rescale_scale.
+ */
 void RescaleColorMap::execute()
 {
   auto field = getRequiredInput(Field);

--- a/src/Modules/Visualization/RescaleColorMap.cc
+++ b/src/Modules/Visualization/RescaleColorMap.cc
@@ -99,8 +99,8 @@ void RescaleColorMap::execute()
       state->setValue(Parameters::FixedMin, fixed_min);
       state->setValue(Parameters::FixedMax, fixed_max);
     }
-    cm_scale = (actual_max - actual_min) / (fixed_max - fixed_min);
-    cm_shift = (actual_min - fixed_min) / (fixed_max - fixed_min);
+    cm_shift =  - fixed_min;
+    cm_scale = 1. / (fixed_max - fixed_min);
 
     sendOutput(ColorMapOutput, StandardColorMapFactory::create(colorMap->getColorMapName(),
       colorMap->getColorMapResolution(),

--- a/src/Modules/Visualization/ShowColorMapModule.cc
+++ b/src/Modules/Visualization/ShowColorMapModule.cc
@@ -68,7 +68,7 @@ void ShowColorMapModule::execute()
   if (needToExecute())
   {
     std::ostringstream ostr;
-    ostr << get_id() << "_" << colorMap->getColorMapActualMin() << colorMap->getColorMapActualMax() <<
+    ostr << get_id() << "_" <<
       colorMap->getColorMapInvert() << colorMap->getColorMapName() << colorMap->getColorMapRescaleScale() <<
       colorMap->getColorMapRescaleShift() << colorMap->getColorMapResolution() << colorMap.get() <<
       colorMap->getColorMapShift();
@@ -81,21 +81,25 @@ GeometryHandle
 ShowColorMapModule::buildGeometryObject(ColorMapHandle cm, ModuleStateHandle state, const std::string& id)
 {
   std::vector<Vector> points;
-  std::vector<double> colors;
+  std::vector<ColorRGB> colors;
   std::vector<uint32_t> indices;
   int32_t numVBOElements = 0;
   ColorMap * map = cm.get();
   double resolution = 1. / static_cast<double>(map->getColorMapResolution());
+  //show colormap does not rescale colors, so reset them. we want to see the whole colormap on the scale.
+  ColorMap new_map(map->getColorMapName(),map->getColorMapResolution(),
+                   map->getColorMapShift(),map->getColorMapInvert(), 1.,0.);
   for (double i = 0.; std::abs(i - 1.) > 0.000001; i += resolution) {
+    ColorRGB col = new_map.valueToColor(i);
     uint32_t offset = (uint32_t)points.size();
     points.push_back(Vector(0., i, 0.));
-    colors.push_back(i);
+    colors.push_back(col);
     points.push_back(Vector(1., i, 0.));
-    colors.push_back(i);
+    colors.push_back(col);
     points.push_back(Vector(0., i + resolution, 0.));
-    colors.push_back(i);
+    colors.push_back(col);
     points.push_back(Vector(1., i + resolution, 0.));
-    colors.push_back(i);
+    colors.push_back(col);
     numVBOElements += 2;
     indices.push_back(offset + 0);
     indices.push_back(offset + 1);
@@ -107,7 +111,7 @@ ShowColorMapModule::buildGeometryObject(ColorMapHandle cm, ModuleStateHandle sta
 
   // IBO/VBOs and sizes
   uint32_t iboSize = sizeof(uint32_t) * (uint32_t)indices.size();
-  uint32_t vboSize = sizeof(float) * 4 * (uint32_t)points.size();
+  uint32_t vboSize = sizeof(float) * 7 * (uint32_t)points.size();
 
   std::shared_ptr<CPM_VAR_BUFFER_NS::VarBuffer> iboBufferSPtr(
     new CPM_VAR_BUFFER_NS::VarBuffer(vboSize));
@@ -123,7 +127,10 @@ ShowColorMapModule::buildGeometryObject(ColorMapHandle cm, ModuleStateHandle sta
     vboBuffer->write(static_cast<float>(points[i].x()));
     vboBuffer->write(static_cast<float>(points[i].y()));
     vboBuffer->write(static_cast<float>(points[i].z()));
-    vboBuffer->write(static_cast<float>(colors[i]));
+    vboBuffer->write(static_cast<float>(colors[i].r()));
+    vboBuffer->write(static_cast<float>(colors[i].g()));
+    vboBuffer->write(static_cast<float>(colors[i].b()));
+    vboBuffer->write(static_cast<float>(1.f));
   }
 
   //add the actual points and colors
@@ -153,7 +160,7 @@ ShowColorMapModule::buildGeometryObject(ColorMapHandle cm, ModuleStateHandle sta
   std::string shader = "Shaders/ColorMapLegend";
   std::vector<GeometryObject::SpireVBO::AttributeData> attribs;
   attribs.push_back(GeometryObject::SpireVBO::AttributeData("aPos", 3 * sizeof(float)));
-  attribs.push_back(GeometryObject::SpireVBO::AttributeData("aFieldData", 1 * sizeof(float)));
+  attribs.push_back(GeometryObject::SpireVBO::AttributeData("aColor", 4 * sizeof(float)));
   std::vector<GeometryObject::SpireSubPass::Uniform> uniforms;
   bool extraSpace = state->getValue(AddExtraSpace).toBool();
   uniforms.push_back(GeometryObject::SpireSubPass::Uniform("uExtraSpace", extraSpace ? 1.f : 0.f));
@@ -162,24 +169,17 @@ ShowColorMapModule::buildGeometryObject(ColorMapHandle cm, ModuleStateHandle sta
   uniforms.push_back(GeometryObject::SpireSubPass::Uniform("uDisplayLength", static_cast<float>(displayLength)));
   GeometryObject::SpireVBO geomVBO = GeometryObject::SpireVBO(vboName, attribs, vboBufferSPtr,
     numVBOElements, Core::Geometry::BBox(), true);
-  //push the color map parameters
-  uniforms.push_back(GeometryObject::SpireSubPass::Uniform("uCMInvert", map->getColorMapInvert() ? 1.f : 0.f));
-  uniforms.push_back(GeometryObject::SpireSubPass::Uniform("uCMShift", static_cast<float>(map->getColorMapShift())));
-  uniforms.push_back(GeometryObject::SpireSubPass::Uniform("uCMResolution", static_cast<float>(map->getColorMapResolution())));
 
   // Construct IBO.
 
   GeometryObject::SpireIBO geomIBO(iboName, GeometryObject::SpireIBO::TRIANGLES, sizeof(uint32_t), iboBufferSPtr);
 
   RenderState renState;
-  renState.set(RenderState::USE_COLORMAP, true);
-
-  // Construct Pass.
-  // Build pass for the edges.
-  /// \todo Find an appropriate place to put program names like UniformColor.
-  GeometryObject::ColorScheme scheme = GeometryObject::COLOR_MAP;
+  renState.set(RenderState::IS_ON, true);
+  renState.set(RenderState::HAS_DATA, true);
+  
   GeometryObject::SpireSubPass pass(passName, vboName, iboName, shader,
-    scheme, renState, GeometryObject::RENDER_VBO_IBO, geomVBO, geomIBO);
+    GeometryObject::COLOR_MAP, renState, GeometryObject::RENDER_VBO_IBO, geomVBO, geomIBO);
 
   // Add all uniforms generated above to the pass.
   for (const auto& uniform : uniforms) { pass.addUniform(uniform); }
@@ -206,9 +206,7 @@ ShowColorMapModule::buildGeometryObject(ColorMapHandle cm, ModuleStateHandle sta
 
   for (double i = 0.; i <= 1.000000001; i += increment) {
     std::stringstream ss;
-    sprintf(str2, sd.str().c_str(), ((cm->getColorMapActualMax() -
-      cm->getColorMapActualMin()) * i +
-      cm->getColorMapActualMin()) * scale);
+    sprintf(str2, sd.str().c_str(), i / cm->getColorMapRescaleScale() - cm->getColorMapRescaleShift());
     ss << str2 << " " << st->getValue(Units).toString();
     text_.reset(ss.str(), textSize, Vector((displaySide == 0) ? 40. : 1., (displaySide == 0) ? 0. : 20., i));
     std::vector<Vector> tmp;
@@ -281,14 +279,9 @@ ShowColorMapModule::buildGeometryObject(ColorMapHandle cm, ModuleStateHandle sta
   GeometryObject::SpireIBO geomIBO2(iboName, GeometryObject::SpireIBO::POINTS, sizeof(uint32_t), iboBufferSPtr2);
   geom->mIBOs.push_back(geomIBO2);
   renState.set(RenderState::USE_COLORMAP, false);
-  //renState.set(RenderState::USE_TRANSPARENT_NODES, true);
-
-  // Construct Pass.
-  // Build pass for the edges.
-  /// \todo Find an appropriate place to put program names like UniformColor.
-  scheme = GeometryObject::COLOR_UNIFORM;
+  
   GeometryObject::SpireSubPass pass2(passName, vboName, iboName, shader,
-    scheme, renState, GeometryObject::RENDER_VBO_IBO, geomVBO2, geomIBO2);
+    GeometryObject::COLOR_MAP, renState, GeometryObject::RENDER_VBO_IBO, geomVBO2, geomIBO2);
 
   // Add all uniforms generated above to the pass.
   for (const auto& uniform : uniforms) { pass2.addUniform(uniform); }

--- a/src/Modules/Visualization/ShowField.cc
+++ b/src/Modules/Visualization/ShowField.cc
@@ -586,7 +586,7 @@ void ShowFieldModule::renderFacesLinear(
   }
 
   std::stringstream ss;
-  ss << invertNormals << colorScheme;
+  ss << invertNormals << colorScheme << faceTransparencyValue_;
 
   std::string uniqueNodeID = id + "face" + ss.str();
   std::string vboName = uniqueNodeID + "VBO";
@@ -605,6 +605,9 @@ void ShowFieldModule::renderFacesLinear(
   {
     attribs.push_back(GeometryObject::SpireVBO::AttributeData("aNormal", 3 * sizeof(float)));
   }
+
+  if (state.get(RenderState::USE_TRANSPARENCY))
+    uniforms.push_back(GeometryObject::SpireSubPass::Uniform("uTransparency", faceTransparencyValue_));
 
   if (colorScheme == GeometryObject::COLOR_MAP)
   {
@@ -647,15 +650,6 @@ void ShowFieldModule::renderFacesLinear(
         // Use colormapping only shader.
         shader = "Shaders/DblSided_ColorMap";
       }
-    }
-
-    if (state.get(RenderState::USE_TRANSPARENCY))
-    {
-      uniforms.push_back(GeometryObject::SpireSubPass::Uniform("uTransparency", (faceTransparencyValue_)));
-    }
-    else
-    {
-      uniforms.push_back(GeometryObject::SpireSubPass::Uniform("uTransparency", (1.0f)));
     }
   }
   else if (colorScheme == GeometryObject::COLOR_IN_SITU)
@@ -711,32 +705,14 @@ void ShowFieldModule::renderFacesLinear(
       uniforms.push_back(GeometryObject::SpireSubPass::Uniform("uSpecularColor",
         glm::vec4(0.1f, 0.1f, 0.1f, 0.1f)));
       uniforms.push_back(GeometryObject::SpireSubPass::Uniform("uSpecularPower", 32.0f));
-
-      if (state.get(RenderState::USE_TRANSPARENCY))
-      {
-        uniforms.push_back(GeometryObject::SpireSubPass::Uniform(
-          "uDiffuseColor", glm::vec4(defaultColor.r(), defaultColor.g(), defaultColor.b(), faceTransparencyValue_)));
-      }
-      else
-      {
-        uniforms.push_back(GeometryObject::SpireSubPass::Uniform(
-          "uDiffuseColor", glm::vec4(defaultColor.r(), defaultColor.g(), defaultColor.b(), 1.0f)));
-      }
+      uniforms.push_back(GeometryObject::SpireSubPass::Uniform(
+        "uDiffuseColor", glm::vec4(defaultColor.r(), defaultColor.g(), defaultColor.b(), 1.0f)));
     }
     else
     {
       shader = "Shaders/UniformColor";
-      if (state.get(RenderState::USE_TRANSPARENCY))
-      {
-        /// \todo Add transparency slider.
-        uniforms.push_back(GeometryObject::SpireSubPass::Uniform(
-          "uColor", glm::vec4(defaultColor.r(), defaultColor.g(), defaultColor.b(), faceTransparencyValue_)));
-      }
-      else
-      {
-        uniforms.push_back(GeometryObject::SpireSubPass::Uniform(
-          "uColor", glm::vec4(defaultColor.r(), defaultColor.g(), defaultColor.b(), 1.0f)));
-      }
+      uniforms.push_back(GeometryObject::SpireSubPass::Uniform(
+        "uColor", glm::vec4(defaultColor.r(), defaultColor.g(), defaultColor.b(), 1.0f)));
     }
   }
 

--- a/src/Modules/Visualization/ShowField.h
+++ b/src/Modules/Visualization/ShowField.h
@@ -106,20 +106,20 @@ namespace SCIRun {
         /// @{
         void renderNodes(
           boost::shared_ptr<SCIRun::Field> field,
-          const SCIRun::Core::Datatypes::ColorMap &colorMap,
+          boost::optional<boost::shared_ptr<SCIRun::Core::Datatypes::ColorMap>> colorMap,
           RenderState state, Core::Datatypes::GeometryHandle geom,
           const std::string& id);
 
         void renderFaces(
           boost::shared_ptr<SCIRun::Field> field,
-          const SCIRun::Core::Datatypes::ColorMap &colorMap,
+          boost::optional<boost::shared_ptr<SCIRun::Core::Datatypes::ColorMap>> colorMap,
           RenderState state, Core::Datatypes::GeometryHandle geom,
           unsigned int approx_div,
           const std::string& id);
 
         void renderFacesLinear(
           boost::shared_ptr<SCIRun::Field> field,
-          const SCIRun::Core::Datatypes::ColorMap &colorMap,
+          boost::optional<boost::shared_ptr<SCIRun::Core::Datatypes::ColorMap>> colorMap,
           RenderState state, Core::Datatypes::GeometryHandle geom,
           unsigned int approxDiv,
           const std::string& id);
@@ -137,7 +137,7 @@ namespace SCIRun {
 
         void renderEdges(
           boost::shared_ptr<SCIRun::Field> field,
-          const SCIRun::Core::Datatypes::ColorMap &colorMap,
+          boost::optional<boost::shared_ptr<SCIRun::Core::Datatypes::ColorMap>> colorMap,
           RenderState state,
           Core::Datatypes::GeometryHandle geom,
           const std::string& id);

--- a/src/Modules/Visualization/ShowField.h
+++ b/src/Modules/Visualization/ShowField.h
@@ -106,20 +106,20 @@ namespace SCIRun {
         /// @{
         void renderNodes(
           boost::shared_ptr<SCIRun::Field> field,
-          SCIRun::Core::Datatypes::ColorMap colorMap,
+          const SCIRun::Core::Datatypes::ColorMap &colorMap,
           RenderState state, Core::Datatypes::GeometryHandle geom,
           const std::string& id);
 
         void renderFaces(
           boost::shared_ptr<SCIRun::Field> field,
-          SCIRun::Core::Datatypes::ColorMap colorMap,
+          const SCIRun::Core::Datatypes::ColorMap &colorMap,
           RenderState state, Core::Datatypes::GeometryHandle geom,
           unsigned int approx_div,
           const std::string& id);
 
         void renderFacesLinear(
           boost::shared_ptr<SCIRun::Field> field,
-          SCIRun::Core::Datatypes::ColorMap colorMap,
+          const SCIRun::Core::Datatypes::ColorMap &colorMap,
           RenderState state, Core::Datatypes::GeometryHandle geom,
           unsigned int approxDiv,
           const std::string& id);
@@ -132,12 +132,12 @@ namespace SCIRun {
           CPM_VAR_BUFFER_NS::VarBuffer* iboBuffer,
           CPM_VAR_BUFFER_NS::VarBuffer* vboBuffer,
           Core::Datatypes::GeometryObject::ColorScheme colorScheme,
-          std::vector<SCIRun::Core::Datatypes::ColorRGB> &face_colors,
+          const std::vector<SCIRun::Core::Datatypes::ColorRGB> &face_colors,
           const RenderState& state);
 
         void renderEdges(
           boost::shared_ptr<SCIRun::Field> field,
-          SCIRun::Core::Datatypes::ColorMap colorMap,
+          const SCIRun::Core::Datatypes::ColorMap &colorMap,
           RenderState state,
           Core::Datatypes::GeometryHandle geom,
           const std::string& id);

--- a/src/Modules/Visualization/ShowField.h
+++ b/src/Modules/Visualization/ShowField.h
@@ -131,8 +131,7 @@ namespace SCIRun {
           CPM_VAR_BUFFER_NS::VarBuffer* iboBuffer,
           CPM_VAR_BUFFER_NS::VarBuffer* vboBuffer,
           Core::Datatypes::GeometryObject::ColorScheme colorScheme,
-          std::vector<double> &scols,
-          std::vector<Core::Datatypes::Material> &vcols,
+          std::vector<SCIRun::Core::Datatypes::ColorRGB> &face_colors,
           const RenderState& state);
 
         void renderEdges(
@@ -157,10 +156,7 @@ namespace SCIRun {
           Dataflow::Networks::ModuleStateHandle state,
           boost::optional<boost::shared_ptr<SCIRun::Core::Datatypes::ColorMap>> colorMap);
         /// @}
-
-        void applyColorMapScaling(boost::shared_ptr<SCIRun::Field> field,
-          Core::Datatypes::GeometryObject::SpireSubPass& pass);
-
+        
         float faceTransparencyValue_;
         float edgeTransparencyValue_;
         float nodeTransparencyValue_;

--- a/src/Modules/Visualization/ShowField.h
+++ b/src/Modules/Visualization/ShowField.h
@@ -32,6 +32,7 @@ DEALINGS IN THE SOFTWARE.
 
 #include <Dataflow/Network/Module.h>
 #include <Core/Datatypes/Geometry.h>
+#include <Core/Datatypes/ColorMap.h>
 #include <Core/Datatypes/Legacy/Field/VMesh.h>
 #include <Core/Algorithms/Visualization/RenderFieldState.h>
 #include <Modules/Visualization/share.h>
@@ -105,20 +106,20 @@ namespace SCIRun {
         /// @{
         void renderNodes(
           boost::shared_ptr<SCIRun::Field> field,
-          boost::optional<boost::shared_ptr<SCIRun::Core::Datatypes::ColorMap>> colorMap,
+          SCIRun::Core::Datatypes::ColorMap colorMap,
           RenderState state, Core::Datatypes::GeometryHandle geom,
           const std::string& id);
 
         void renderFaces(
           boost::shared_ptr<SCIRun::Field> field,
-          boost::optional<boost::shared_ptr<SCIRun::Core::Datatypes::ColorMap>> colorMap,
+          SCIRun::Core::Datatypes::ColorMap colorMap,
           RenderState state, Core::Datatypes::GeometryHandle geom,
           unsigned int approx_div,
           const std::string& id);
 
         void renderFacesLinear(
           boost::shared_ptr<SCIRun::Field> field,
-          boost::optional<boost::shared_ptr<SCIRun::Core::Datatypes::ColorMap>> colorMap,
+          SCIRun::Core::Datatypes::ColorMap colorMap,
           RenderState state, Core::Datatypes::GeometryHandle geom,
           unsigned int approxDiv,
           const std::string& id);
@@ -136,7 +137,7 @@ namespace SCIRun {
 
         void renderEdges(
           boost::shared_ptr<SCIRun::Field> field,
-          boost::optional<boost::shared_ptr<SCIRun::Core::Datatypes::ColorMap>> colorMap,
+          SCIRun::Core::Datatypes::ColorMap colorMap,
           RenderState state,
           Core::Datatypes::GeometryHandle geom,
           const std::string& id);


### PR DESCRIPTION
ColorMap.cc object is no longer in SRInterface.cc, it is only seen from CreateStandardColorMap.cc -> ShowField.cc modules. 

All algorithms for retrieving color map values are contained in ColorMap.cc and taken out of shaders.

Did regression tests with:

1. rescaleColorMap.srn5
2. test_basis.scn5
3. simple latVol
4. simple colorMap
5. tikinov
6. inverseForwardProblem
7. simple boundingBox