### PR TITLE
Check Binary Path Length For Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,9 +53,10 @@ ENDIF()
 if(WIN32)
 	STRING(LENGTH ${CMAKE_BINARY_DIR} BIN_DIR_LENGTH)
 	if(${BIN_DIR_LENGTH} GREATER 10)
-		MESSAGE(WARNING "Binary directory is too long, which could  cause the build to fail.")
+		MESSAGE(WARNING "Binary directory is too long, the build may fail due to long path names.")
 	endif()
 endif()
+
 ########################################################################
 # Build shared libraries by default
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,15 @@ IF(${CMAKE_SOURCE_DIR} MATCHES ${CMAKE_BINARY_DIR})
   MESSAGE( FATAL_ERROR "Goodbye." )
 ENDIF()
 
-
+################################################################################
+# If building on Windows, make sure that the path to the bin directory is short.
+#
+if(WIN32)
+	STRING(LENGTH ${CMAKE_BINARY_DIR} BIN_DIR_LENGTH)
+	if(${BIN_DIR_LENGTH} GREATER 10)
+		MESSAGE(WARNING "Binary directory is too long, which could  cause the build to fail.")
+	endif()
+endif()
 ########################################################################
 # Build shared libraries by default
 


### PR DESCRIPTION
Added a warning to src/CMakeLists.txt. If the binary path is longer than 10 characters and SCIRun is being build on Windows, a warning message is displayed.