### PR TITLE
Distance field fix

### DIFF
--- a/src/Core/Datatypes/Legacy/Field/TriSurfMesh.h
+++ b/src/Core/Datatypes/Legacy/Field/TriSurfMesh.h
@@ -1096,49 +1096,32 @@ public:
                                        points_[faces_[idx+1]],
                                        points_[faces_[idx+2]]);
 
+                  // middle of the triangle for checking which face is closer when closest point is on the edge
                   const Core::Geometry::Point &p_mean = (points_[faces_[idx  ]] + points_[faces_[idx+1]] + points_[faces_[idx+2]])/3;
                   double dtmp = (p - r).length2();
                   double dtmp2=dtmp;
                     
                   if ((p_mean-r).length2()>=epsilon2_)
                   {
+                    // check a second point on the triangle to confirm it is really closest
                     Core::Geometry::Vector f_v= Core::Geometry::Vector(p_mean-r); f_v.normalize();
                     dtmp2 = (p - Core::Geometry::Point(p_mean+(f_v*epsilon_*1e6))).length2();
                   }
-                  /*
-                    std::cout<< "p = "<< p <<std::endl;
-                    std::cout<< "r = "<< r <<std::endl;
-                    std::cout<< "p_mean = "<< p_mean <<std::endl;
-                    std::cout<< "dmin = " << dmin << ";  dtmp = "<< dtmp <<std::endl;
-                  std::cout<< "dtmp - dmin= " << dtmp - dmin <<std::endl;
-                    std::cout<< "dmean = " << dmean << ";  dtmp2 = "<< dtmp2 <<std::endl;
-                  std::cout<< "dtmp2 - dmean= " << dtmp2 - dmean <<std::endl;
                   
-                  if (std::abs(dtmp - dmin)<= epsilon_)
-                  {
-                    //std::cout<< "machine precision problem. "<<std::endl;
-                  }
-
-                  */
+                  //check for closest face and check within precision
                   
-                  if (dtmp-dmin <= epsilon_)
+                  if (dtmp-dmin <= epsilon2_)
                   {
-                    //std::cout<<"distance less or equal"<<std::endl;
-                    
-                    if (dtmp-dmin < - epsilon_)
+                    if (dtmp-dmin < - epsilon2_)
                     {
                       found_one = true;
                       result = r;
                       face = INDEX(*it);
                       dmin = dtmp;
                       dmean =dtmp2;
-                        
-                        //std::cout<< "normal.  face "<< face <<std::endl<<std::endl;
                       
                       if (dmin < epsilon2_)
                       {
-                        
-                        //std::cout<< "below threshold "<< face <<std::endl<<std::endl;
                         
                         pdist = sqrt(dmin);
                             
@@ -1147,7 +1130,7 @@ public:
                         return (true);
                       }
                     }
-                    else if ( dtmp2-dmean < -epsilon_ )
+                    else if ( dtmp2-dmean < -epsilon2_ )
                     {
                       found_one = true;
                       result = r;
@@ -1155,7 +1138,7 @@ public:
                       if (dmin>=dtmp) dmin=dtmp;
                       dmean =dtmp2;
                     }
-                    else if ( dtmp<dmin  && std::abs(dtmp2-dmean) < epsilon_ )
+                    else if ( dtmp<dmin  && std::abs(dtmp2-dmean) < epsilon2_ )
                     {
                       found_one = true;
                       result = r;
@@ -1163,12 +1146,8 @@ public:
                       dmin = dtmp;
                       dmean =dtmp2;
                       
-                      //std::cout<< "normal within precision.  face "<< face <<std::endl<<std::endl;
-                      
                       if (dmin < epsilon2_)
                       {
-                        
-                        //std::cout<< "below threshold within precision "<< face <<std::endl<<std::endl;
                         
                         pdist = sqrt(dmin);
                         
@@ -1176,21 +1155,13 @@ public:
                         basis_.get_coords(coords,result,ed);
                       }
                     }
-                    else if (dtmp2 < dmean && dtmp-dmin > - epsilon_)
+                    else if (dtmp2 < dmean && dtmp-dmin > - epsilon2_)
                     {
                       found_one = true;
                       result = r;
                       face = INDEX(*it);
                       dmean =dtmp2;
-                      //std::cout<< "machine precision fix.  face "<< face <<std::endl<<std::endl;
                     }
-                    
-                    
-                      
-                      //std::cout<< "same dist, higher mean, skipping.  index "<< idx <<std::endl<<std::endl;
-                      
-                      
-                    
                   }
                   
 

--- a/src/Core/Datatypes/Legacy/Field/TriSurfMesh.h
+++ b/src/Core/Datatypes/Legacy/Field/TriSurfMesh.h
@@ -1103,7 +1103,7 @@ public:
                   if ((p_mean-r).length2()>=epsilon2_)
                   {
                     Core::Geometry::Vector f_v= Core::Geometry::Vector(p_mean-r); f_v.normalize();
-                    dtmp2 = (p - Core::Geometry::Point(p_mean+f_v)).length2();
+                    dtmp2 = (p - Core::Geometry::Point(p_mean+(f_v*epsilon_*1e6))).length2();
                   }
                   /*
                     std::cout<< "p = "<< p <<std::endl;

--- a/src/Core/Datatypes/Legacy/Field/TriSurfMesh.h
+++ b/src/Core/Datatypes/Legacy/Field/TriSurfMesh.h
@@ -1062,7 +1062,7 @@ public:
 
     double dmin = maxdist;
     double dmean = maxdist;
-    double perturb= epsilon_*1e6; //value to move to find new point.
+    const double perturb= epsilon_*1e6; //value to move to find new point.
     bool found = true;
     bool found_one = false;
 

--- a/src/Core/Datatypes/Legacy/Field/TriSurfMesh.h
+++ b/src/Core/Datatypes/Legacy/Field/TriSurfMesh.h
@@ -1062,6 +1062,7 @@ public:
 
     double dmin = maxdist;
     double dmean = maxdist;
+    double perturb= epsilon_*1e6; //value to move to find new point.
     bool found = true;
     bool found_one = false;
 
@@ -1105,7 +1106,7 @@ public:
                   {
                     // check a second point on the triangle to confirm it is really closest
                     Core::Geometry::Vector f_v= Core::Geometry::Vector(p_mean-r); f_v.normalize();
-                    dtmp2 = (p - Core::Geometry::Point(p_mean+(f_v*epsilon_*1e6))).length2();
+                    dtmp2 = (p - Core::Geometry::Point(p_mean+(f_v*perturb))).length2();
                   }
                   
                   //check for closest face and check within precision


### PR DESCRIPTION
This should fixe the problem with signed distance field calculation for trisurf meshes with normals all facing the same way.  There is still a problem with faces of differing orientations.  I might require a new module to reorder normals coherently.  there is also still a problem with quad surfaces, but the fix is probably the same as used here.
