### PR TITLE
Fix line-ending problem for ascii fields

### DIFF
--- a/src/Core/Algorithms/Legacy/DataIO/ObjToFieldReader.cc
+++ b/src/Core/Algorithms/Legacy/DataIO/ObjToFieldReader.cc
@@ -119,12 +119,12 @@ ObjToFieldReader::read(const std::string& filename, FieldHandle& field_handle)
 bool
 ObjToFieldReader::write(const std::string& filename, const FieldHandle& field)
 {
-  std::ofstream os;
   const VMesh* mesh = field->vmesh();
 
   if (mesh->num_nodes() == 0) { return false; }
 
-  os.open(filename.c_str(), std::ios::out);
+  std::ofstream os(filename.c_str(), std::ios_base::binary | std::ios_base::out);
+
   if (!os) { return false; }
 
   os << "# written by SCIRun\n";

--- a/src/Core/Persistent/Pstreams.cc
+++ b/src/Core/Persistent/Pstreams.cc
@@ -822,7 +822,7 @@ TextPiostream::TextPiostream(const std::string& filename, Direction dir,
   else
   {
     istr=0;
-    ostr=new std::ofstream(filename.c_str());
+    ostr = new std::ofstream(filename.c_str(), std::ios_base::binary | std::ios_base::out);
     std::ostream& out=*ostr;
     if (!out)
     {


### PR DESCRIPTION
This will fix the problem going forward. For old versions of Windows-saved ASCII field files, first run a line-ending conversion tool on them to read them in Linux.