### PR TITLE
Preferences library needs to have python path changed in OS X app.

### DIFF
--- a/src/Main/CMakeLists.txt
+++ b/src/Main/CMakeLists.txt
@@ -180,6 +180,7 @@ IF(APPLE)
             WORKING_DIRECTORY ${SCIRun_BINARY_DIR})
 
         SET(SCIRUN_LIBS "Core_Application"
+                        "Core_Application_Preferences"
                         "Core_Python"
                         "SCIRunPythonAPI"
                         "Interface_Application"
@@ -244,6 +245,7 @@ IF(APPLE)
             WORKING_DIRECTORY ${SCIRun_BINARY_DIR})
 
         SET(SCIRUN_LIBS "Core_Application"
+                        "Core_Application_Preferences"
                         "Core_Python"
                         "SCIRunPythonAPI"
                         "Engine_Network"


### PR DESCRIPTION
OS X app build fix. Installer has been updated and uploaded already.


