### PR TITLE
GCC6.2 fix

### DIFF
--- a/src/Core/Datatypes/Legacy/Field/HexVolMesh.h
+++ b/src/Core/Datatypes/Legacy/Field/HexVolMesh.h
@@ -2649,9 +2649,9 @@ protected:
 
     /// These are for our own use (making the hash function.
     static const int sz_quarter_int = (int)(sz_int / 4);
-    static const int top4_mask = ((~((int)0)) << sz_quarter_int << sz_quarter_int << sz_quarter_int);
-    static const int up4_mask = top4_mask ^ (~((int)0) << sz_quarter_int << sz_quarter_int);
-    static const int mid4_mask =  top4_mask ^ (~((int)0) << sz_quarter_int);
+    static const int top4_mask = -(1 << sz_quarter_int << sz_quarter_int << sz_quarter_int);
+    static const int up4_mask = top4_mask ^ -(1 << sz_quarter_int << sz_quarter_int);
+    static const int mid4_mask =  top4_mask ^ -(1 << sz_quarter_int);
     static const int low4_mask = ~(top4_mask | mid4_mask);
 
     /// This is the hash function
@@ -2714,7 +2714,7 @@ protected:
     /// These are for our own use (making the hash function.
     static const int sz_int = sizeof(int) * 8; // in bits
     static const int sz_half_int = sizeof(int) << 2; // in bits
-    static const int up_mask = ((~((int)0)) << sz_half_int);
+    static const int up_mask = -(1 << sz_half_int);
     static const int low_mask = (~((int)0) ^ up_mask);
 
     /// This is the hash function

--- a/src/Core/Datatypes/Legacy/Field/PrismVolMesh.h
+++ b/src/Core/Datatypes/Legacy/Field/PrismVolMesh.h
@@ -2408,9 +2408,9 @@ protected:
 
     /// These are for our own use (making the hash function.
     static const int sz_quarter_int = (int)(sz_int / 4);
-    static const int top4_mask = ((~((int)0)) << sz_quarter_int << sz_quarter_int << sz_quarter_int);
-    static const int up4_mask = top4_mask ^ (~((int)0) << sz_quarter_int << sz_quarter_int);
-    static const int mid4_mask =  top4_mask ^ (~((int)0) << sz_quarter_int);
+    static const int top4_mask = -(1 << sz_quarter_int << sz_quarter_int << sz_quarter_int);
+    static const int up4_mask = top4_mask ^ -(1 << sz_quarter_int << sz_quarter_int);
+    static const int mid4_mask =  top4_mask ^ -(1 << sz_quarter_int);
     static const int low4_mask = ~(top4_mask | mid4_mask);
 
     /// This is the hash function
@@ -2451,7 +2451,7 @@ protected:
     /// These are for our own use (making the hash function.
     static const int sz_int = sizeof(int) * 8; // in bits
     static const int sz_half_int = sizeof(int) << 2; // in bits
-    static const int up_mask = ((~((int)0)) << sz_half_int);
+    static const int up_mask = -(1 << sz_half_int);
     static const int low_mask = (~((int)0) ^ up_mask);
 
     /// This is the hash function

--- a/src/Core/Datatypes/Legacy/Field/TetVolMesh.h
+++ b/src/Core/Datatypes/Legacy/Field/TetVolMesh.h
@@ -2479,8 +2479,8 @@ protected:
 
     /// These are for our own use (making the hash function).
     static const int sz_third_int = (int)(sz_int / 3);
-    static const int up_mask = (~((int)0) << sz_third_int << sz_third_int);
-    static const int mid_mask =  up_mask ^ (~((int)0) << sz_third_int);
+    static const int up_mask = -(1 << sz_third_int << sz_third_int);
+    static const int mid_mask =  up_mask ^ -(1 << sz_third_int);
     static const int low_mask = ~(up_mask | mid_mask);
 
     /// This is the hash function
@@ -2513,7 +2513,7 @@ protected:
     /// These are for our own use (making the hash function.
     static const int sz_int = sizeof(int) * 8; // in bits
     static const int sz_half_int = sizeof(int) << 2; // in bits
-    static const int up_mask = ((~((int)0)) << sz_half_int);
+    static const int up_mask = -(1 << sz_half_int);
     static const int low_mask = (~((int)0) ^ up_mask);
 
     /// This is the hash function

--- a/src/Core/Parser/Tests/ParserTests.cc
+++ b/src/Core/Parser/Tests/ParserTests.cc
@@ -1586,8 +1586,8 @@ TEST(FieldHashTests, TestShiftingZero)
 
   /// These are for our own use (making the hash function).
   static const int sz_third_int = (int)(sz_int / 3);
-  static const int up_mask = (~((int)0) << sz_third_int << sz_third_int);
-  static const int mid_mask = up_mask ^ (~((int)0) << sz_third_int);
+  static const int up_mask = -1048576; // (~((int)0) << sz_third_int << sz_third_int);
+  static const int mid_mask = 1047552; // up_mask ^ (~((int)0) << sz_third_int);
   static const int low_mask = ~(up_mask | mid_mask);
 
   std::cout << "sz_int: " << sz_int << std::endl;

--- a/src/Core/Parser/Tests/ParserTests.cc
+++ b/src/Core/Parser/Tests/ParserTests.cc
@@ -1579,3 +1579,33 @@ TEST_F(BasicParserTests, CreateFieldData_fracanisotropy)
 
 */
 
+TEST(FieldHashTests, TestShiftingZero)
+{
+  // copied from TetVolMesh.h, failing compilation on GCC 6.2.
+  static const int sz_int = sizeof(int) * 8; // in bits
+
+  /// These are for our own use (making the hash function).
+  static const int sz_third_int = (int)(sz_int / 3);
+  static const int up_mask = (~((int)0) << sz_third_int << sz_third_int);
+  static const int mid_mask = up_mask ^ (~((int)0) << sz_third_int);
+  static const int low_mask = ~(up_mask | mid_mask);
+
+  std::cout << "sz_int: " << sz_int << std::endl;
+  std::cout << "sz_third_int: " << sz_third_int << std::endl;
+  std::cout << "up_mask: " << up_mask << std::endl;
+  std::cout << "mid_mask: " << mid_mask << std::endl;
+  std::cout << "low_mask: " << low_mask << std::endl;
+
+  auto badGcc = ~((int)0);
+  std::cout << "badGcc: " << badGcc << std::endl;
+  
+  auto redo_up_mask = -(1 << 10 << 10);
+  std::cout << "redo_up_mask: " << redo_up_mask << std::endl;
+
+  auto redo_mid_mask = redo_up_mask ^ (-(1 << sz_third_int));
+  auto redo_low_mask = ~(redo_up_mask | redo_mid_mask);
+
+  ASSERT_EQ(redo_up_mask, up_mask);
+  ASSERT_EQ(redo_mid_mask, mid_mask);
+  ASSERT_EQ(redo_low_mask, low_mask);
+}


### PR DESCRIPTION
Closes #1655.

I wrote a unit test to ensure these masks have the same value. The compiler didn't like bit shifting a negative number.