### PR TITLE
Boost revert--FAST TRACK REVIEW/MERGE PLEASE

### DIFF
--- a/Superbuild/BoostExternal.cmake
+++ b/Superbuild/BoostExternal.cmake
@@ -73,7 +73,7 @@ IF(WIN32)
   SET(FORCE_64BIT_BUILD ON)
 ENDIF()
 
-SET(boost_GIT_TAG "origin/v1.66.0")
+SET(boost_GIT_TAG "origin/v1.58.0")
 SET(boost_GIT_URL "https://github.com/CIBC-Internal/boost.git")
 
 # TODO: fix install step

--- a/src/Core/Datatypes/Legacy/Bundle/Bundle.cc
+++ b/src/Core/Datatypes/Legacy/Bundle/Bundle.cc
@@ -1,22 +1,16 @@
 /*
   For more information, please see: http://software.sci.utah.edu
-
   The MIT License
-
   Copyright (c) 2015 Scientific Computing and Imaging Institute,
   University of Utah.
-
-
   Permission is hereby granted, free of charge, to any person obtaining a
   copy of this software and associated documentation files (the "Software"),
   to deal in the Software without restriction, including without limitation
   the rights to use, copy, modify, merge, publish, distribute, sublicense,
   and/or sell copies of the Software, and to permit persons to whom the
   Software is furnished to do so, subject to the following conditions:
-
   The above copyright notice and this permission notice shall be included
   in all copies or substantial portions of the Software.
-
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
   OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -41,6 +35,7 @@
 
 #include <boost/range/algorithm/count_if.hpp>
 #include <boost/range/adaptors.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/range/algorithm/copy.hpp>
 
 #ifdef SCIRUN4_CODE_TO_BE_ENABLED_LATER
@@ -48,7 +43,7 @@
 #endif
 
 using namespace SCIRun;
-using namespace Core::Datatypes;
+using namespace SCIRun::Core::Datatypes;
 
 static Persistent* make_Bundle() {
   return new Bundle;
@@ -631,18 +626,18 @@ bool Bundle::isField(const std::string& name) const
 
 size_t Bundle::numFields() const
 {
-  return boost::count_if(bundle_ | boost::adaptors::map_keys, [this](const std::string& name) { return isField(name); });
+  return boost::count_if(bundle_ | boost::adaptors::map_keys, boost::bind(&Bundle::isField, this, _1));
 }
 
 std::vector<FieldHandle> Bundle::getFields() const
 {
-  auto range = bundle_ | boost::adaptors::map_keys | boost::adaptors::transformed([this](const std::string& name) { return getField(name); }) | boost::adaptors::filtered([](FieldHandle f) { return f != nullptr; });
+  auto range = bundle_ | boost::adaptors::map_keys | boost::adaptors::transformed(boost::bind(&Bundle::getField, this, _1)) | boost::adaptors::filtered([] (FieldHandle f) { return f != nullptr; });
   return std::vector<FieldHandle>(range.begin(), range.end());
 }
 
 std::vector<std::string> Bundle::getFieldNames() const
 {
-  auto range = bundle_ | boost::adaptors::map_keys | boost::adaptors::filtered([this](const std::string& name) { return isField(name); });
+  auto range = bundle_ | boost::adaptors::map_keys | boost::adaptors::filtered(boost::bind(&Bundle::isField, this, _1));
   return std::vector<std::string>(range.begin(), range.end());
 }
 
@@ -658,18 +653,18 @@ bool Bundle::isMatrix(const std::string& name) const
 
 size_t Bundle::numMatrices() const
 {
-  return boost::count_if(bundle_ | boost::adaptors::map_keys, [this](const std::string& name) { return isMatrix(name); });
+  return boost::count_if(bundle_ | boost::adaptors::map_keys, boost::bind(&Bundle::isMatrix, this, _1));
 }
 
 std::vector<MatrixHandle> Bundle::getMatrices() const
 {
-  auto range = bundle_ | boost::adaptors::map_keys | boost::adaptors::transformed([this](const std::string& name) { return getMatrix(name); }) | boost::adaptors::filtered([](MatrixHandle m) { return m != nullptr; });
+  auto range = bundle_ | boost::adaptors::map_keys | boost::adaptors::transformed(boost::bind(&Bundle::getMatrix, this, _1)) | boost::adaptors::filtered([] (MatrixHandle m) { return m != nullptr; });
   return std::vector<MatrixHandle>(range.begin(), range.end());
 }
 
 std::vector<std::string> Bundle::getMatrixNames() const
 {
-  auto range = bundle_ | boost::adaptors::map_keys | boost::adaptors::filtered([this](const std::string& name) { return isMatrix(name); });
+  auto range = bundle_ | boost::adaptors::map_keys | boost::adaptors::filtered(boost::bind(&Bundle::isMatrix, this, _1));
   return std::vector<std::string>(range.begin(), range.end());
 }
 
@@ -685,18 +680,18 @@ bool Bundle::isString(const std::string& name) const
 
 size_t Bundle::numStrings() const
 {
-  return boost::count_if(bundle_ | boost::adaptors::map_keys, [this](const std::string& name) { return isString(name); });
+  return boost::count_if(bundle_ | boost::adaptors::map_keys, boost::bind(&Bundle::isString, this, _1));
 }
 
 std::vector<StringHandle> Bundle::getStrings() const
 {
-  auto range = bundle_ | boost::adaptors::map_keys | boost::adaptors::transformed([this](const std::string& name) { return getString(name); }) | boost::adaptors::filtered([](StringHandle s) { return s != nullptr; });
+  auto range = bundle_ | boost::adaptors::map_keys | boost::adaptors::transformed(boost::bind(&Bundle::getString, this, _1)) | boost::adaptors::filtered([] (StringHandle s) { return s != nullptr; });
   return std::vector<StringHandle>(range.begin(), range.end());
 }
 
 std::vector<std::string> Bundle::getStringNames() const
 {
-  auto range = bundle_ | boost::adaptors::map_keys | boost::adaptors::filtered([this](const std::string& name) { return isString(name); });
+  auto range = bundle_ | boost::adaptors::map_keys | boost::adaptors::filtered(boost::bind(&Bundle::isString, this, _1));
   return std::vector<std::string>(range.begin(), range.end());
 }
 

--- a/src/Core/Math/MiscMath.h
+++ b/src/Core/Math/MiscMath.h
@@ -55,7 +55,8 @@ namespace SCIRun {
 template<typename T>
 inline bool nonzero(T d)
 {
-  namespace btt = boost::math::fpc;
+	namespace btt = boost::test_tools;
+  //namespace btt = boost::math::fpc;
   btt::close_at_tolerance<T> comp(btt::percent_tolerance(std::numeric_limits<T>::epsilon()));
   return(! comp(d, 0));
 }

--- a/src/Core/Math/Tests/FloatingPointAssertionTests.cc
+++ b/src/Core/Math/Tests/FloatingPointAssertionTests.cc
@@ -34,8 +34,9 @@ using namespace SCIRun;
 
 TEST(FloatComparisonTest, BoostCheck)
 {
-  using namespace boost::math::fpc;
-  close_at_tolerance<double> comp(percent_tolerance(1e-5));
+  namespace btt = boost::test_tools;
+  //namespace btt = boost::math::fpc;
+  btt::close_at_tolerance<double> comp(btt::percent_tolerance(1e-5));
   EXPECT_TRUE(comp(1, 1));
   EXPECT_FALSE(comp(1.0/3, 0.33333));
   EXPECT_TRUE(comp(1.0/3, 0.333333333));

--- a/src/Testing/Utils/MatrixTestUtilities.h
+++ b/src/Testing/Utils/MatrixTestUtilities.h
@@ -6,7 +6,7 @@
    Copyright (c) 2015 Scientific Computing and Imaging Institute,
    University of Utah.
 
-   
+
    Permission is hereby granted, free of charge, to any person obtaining a
    copy of this software and associated documentation files (the "Software"),
    to deal in the Software without restriction, including without limitation
@@ -44,15 +44,15 @@
 
 #include <Testing/Utils/share.h>
 
-namespace SCIRun 
-{ 
+namespace SCIRun
+{
 
 namespace TestUtils
 {
 
 inline bool equal_size(const Core::Datatypes::Matrix& m1, const Core::Datatypes::Matrix& m2)
 {
-  return m1.nrows() == m2.nrows() 
+  return m1.nrows() == m2.nrows()
     && m1.ncols() == m2.ncols();
 }
 
@@ -61,7 +61,8 @@ inline bool equal_size(const Core::Datatypes::Matrix& m1, const Core::Datatypes:
 //TODO improve error reporting
 inline bool compare_with_tolerance(const Core::Datatypes::DenseMatrix& m1, const Core::Datatypes::DenseMatrix& m2, double percentTolerance = DEFAULT_MATRIX_PERCENT_TOLERANCE)
 {
-  using namespace boost::math::fpc;
+  using namespace boost::test_tools;
+  //using namespace boost::math::fpc;
   return equal_size(m1, m2) &&
     std::equal(m1.data(), m1.data() + m1.size(), m2.data(),
     close_at_tolerance<double>(percent_tolerance(percentTolerance)));
@@ -69,7 +70,8 @@ inline bool compare_with_tolerance(const Core::Datatypes::DenseMatrix& m1, const
 
 inline bool compare_with_tolerance(const Core::Datatypes::SparseRowMatrix& m1, const Core::Datatypes::SparseRowMatrix& m2, double percentTolerance = DEFAULT_MATRIX_PERCENT_TOLERANCE)
 {
-  using namespace boost::math::fpc;
+  using namespace boost::test_tools;
+  //using namespace boost::math::fpc;
   return equal_size(m1, m2) &&
     std::equal(m1.valuePtr(), m1.valuePtr() + m1.nonZeros(), m2.valuePtr(),
     close_at_tolerance<double>(percent_tolerance(percentTolerance)));
@@ -77,7 +79,7 @@ inline bool compare_with_tolerance(const Core::Datatypes::SparseRowMatrix& m1, c
 
 inline ::testing::AssertionResult compare_with_tolerance_readable(const Core::Datatypes::DenseMatrix& m1, const Core::Datatypes::DenseMatrix& m2, double percentTolerance, int printSize = 50)
 {
-  return compare_with_tolerance(m1, m2, percentTolerance) ? 
+  return compare_with_tolerance(m1, m2, percentTolerance) ?
     ::testing::AssertionSuccess() :
   ::testing::AssertionFailure() << "Matrix 1: \n"<< matrix_to_string(m1).substr(0, printSize) << "\nMatrix 2: \n" << matrix_to_string(m2).substr(0, printSize);
 }
@@ -96,12 +98,12 @@ inline double relative_infinity_norm(const Core::Datatypes::DenseColumnMatrix& x
   double num = diff.lpNorm<Eigen::Infinity>();
   double denom = xhat.lpNorm<Eigen::Infinity>();
 
-  return num / denom; 
+  return num / denom;
 }
 
 inline ::testing::AssertionResult compare_with_relative_infinity_norm(const Core::Datatypes::DenseColumnMatrix& x, const Core::Datatypes::DenseColumnMatrix& xhat, double relativeError = DEFAULT_MATRIX_PERCENT_TOLERANCE, int printSize = 50)
 {
-  return relative_infinity_norm(x, xhat) < relativeError ? 
+  return relative_infinity_norm(x, xhat) < relativeError ?
     ::testing::AssertionSuccess() :
   ::testing::AssertionFailure() << "ColumnMatrix 1: \n"<< matrix_to_string(x).substr(0, printSize) << "ColumnMatrix 2: \n" << matrix_to_string(xhat).substr(0, printSize);
 }
@@ -110,7 +112,7 @@ inline ::testing::AssertionResult compare_with_relative_infinity_norm(const Core
 inline ::testing::AssertionResult compare_with_two_norm(const Core::Datatypes::DenseColumnMatrix& x, const Core::Datatypes::DenseColumnMatrix& xhat, double error = 1e-15, int printSize = 50)
 {
   double delta = (x - xhat).norm();
-  return delta < error ? 
+  return delta < error ?
     ::testing::AssertionSuccess() :
   ::testing::AssertionFailure() <<
     "Vectors are " << delta << " apart, expect less than " << error << " distance apart.\n" <<
@@ -146,7 +148,7 @@ inline Core::Datatypes::DenseMatrixHandle makeDense(const Core::Datatypes::Spars
   }
   return dense;
 }
- 
+
 //TODO improve failure reporting
 
 #define EXPECT_MATRIX_EQ_TOLERANCE(actual, expected, tolerance) EXPECT_TRUE(compare_with_tolerance_readable((actual), (expected), (tolerance)))
@@ -167,7 +169,7 @@ inline Core::Datatypes::DenseMatrixHandle makeDense(const Core::Datatypes::Spars
 
 // Note: this approach is limited to matrices with <= 5 columns, due to the implementation of boost::assign::tuple_list_of.
 template <class Tuple>
-Core::Datatypes::DenseMatrix convertDataToMatrix(const std::vector<Tuple>& matrixData) 
+Core::Datatypes::DenseMatrix convertDataToMatrix(const std::vector<Tuple>& matrixData)
 {
   typedef typename boost::tuples::element<0,Tuple>::type element0type;
   typedef boost::is_convertible<element0type, double> CanConvertToDouble;
@@ -207,7 +209,7 @@ inline std::vector<typename Cont::value_type> to_vector(const Cont& cont)
 
 struct SCISHARE ScopedTimer
 {
-  explicit ScopedTimer(const std::string& name) : name_(name) 
+  explicit ScopedTimer(const std::string& name) : name_(name)
   {
     std::cout << "Starting timer " << name_ << std::endl;
     t_.restart();


### PR DESCRIPTION
Argh, back to 1.58. We can try to upgrade again AFTER we switch to PyBind over Boost.Python, since the latter is what caused all the trouble.