### PR TITLE
Double Sided Lighting Fix

### DIFF
--- a/src/Graphics/Glyphs/GlyphGeom.cc
+++ b/src/Graphics/Glyphs/GlyphGeom.cc
@@ -331,6 +331,7 @@ void GlyphGeom::generateSphere(const Point& center, double radius, double resolu
       uint32_t offset = static_cast<uint32_t>(numVBOElements_);
       pp1 = Vector(sin(theta) * cos(phi), sin(theta) * sin(phi), cos(theta));
       pp2 = Vector(sin(theta) * cos(phi + phi_inc), sin(theta) * sin(phi + phi_inc), cos(theta));
+
       normals_.push_back(pp1);
       normals_.push_back(pp2);
       pp1 *= r;
@@ -341,11 +342,20 @@ void GlyphGeom::generateSphere(const Point& center, double radius, double resolu
       points_.push_back(pp2 + Vector(center));
       colors_.push_back(color);
       numVBOElements_++;
+
+      //preserve vertex ordering for double sided rendering
+      int v1 = 1, v2 = 2;
+      if(theta < M_PI)
+      {
+        v1 = 2;
+        v2 = 1;
+      }
+
       indices_.push_back(0 + offset);
-      indices_.push_back(1 + offset);
-      indices_.push_back(2 + offset);
-      indices_.push_back(2 + offset);
-      indices_.push_back(1 + offset);
+      indices_.push_back(v1 + offset);
+      indices_.push_back(v2 + offset);
+      indices_.push_back(v2 + offset);
+      indices_.push_back(v1 + offset);
       indices_.push_back(3 + offset);
     }
     for (int jj = 0; jj < 6; jj++) indices_.pop_back();

--- a/src/Interface/Modules/Render/ES/AssetBootstrap.cc
+++ b/src/Interface/Modules/Render/ES/AssetBootstrap.cc
@@ -24,7 +24,7 @@ namespace Render {
 class AssetBootstrap : public spire::EmptySystem
 {
 public:
-  
+
   static const char* getName() {return "scirun:AssetBootstrap";}
 
   void execute(spire::ESCoreBase& baseCore)
@@ -59,6 +59,7 @@ public:
         // Load shader we will use with the coordinate axes.
       shaderMan->loadVertexAndFragmentShader(core, cachedEntity, "Shaders/DirPhong");
       shaderMan->loadVertexAndFragmentShader(core, cachedEntity, "Shaders/DirPhongNoClipping");
+      shaderMan->loadVertexAndFragmentShader(core, cachedEntity, "Shaders/UniformColor");
     }
 
     // Note: We don't need to strictly store the coordinate axes entity.
@@ -78,5 +79,3 @@ const char* getSystemName_AssetBootstrap() {return AssetBootstrap::getName();}
 
 } // namespace Render
 } // namespace SCIRun
-
-

--- a/src/Interface/Modules/Render/ES/SRInterface.cc
+++ b/src/Interface/Modules/Render/ES/SRInterface.cc
@@ -1388,7 +1388,8 @@ namespace SCIRun {
           {
             GLuint arrowVBO = vboMan->hasVBO("Assets/arrow.geom");
             GLuint arrowIBO = iboMan->hasIBO("Assets/arrow.geom");
-            GLuint shader = shaderMan->getIDForAsset("Shaders/DirPhongNoClipping");
+            //GLuint shader = shaderMan->getIDForAsset("Shaders/DirPhongNoClipping");
+            GLuint shader = shaderMan->getIDForAsset("Shaders/UniformColor");
 
             // Bail if assets have not been loaded yet (asynchronous loading may take a
             // few frames).
@@ -1470,7 +1471,8 @@ namespace SCIRun {
             GLint locLightDirWorld = glGetUniformLocation(shader, "uLightDirWorld");
 
             GLint locAmbientColor = glGetUniformLocation(shader, "uAmbientColor");
-            GLint locDiffuseColor = glGetUniformLocation(shader, "uDiffuseColor");
+            //GLint locDiffuseColor = glGetUniformLocation(shader, "uDiffuseColor");
+            GLint locDiffuseColor = glGetUniformLocation(shader, "uColor");
             GLint locSpecularColor = glGetUniformLocation(shader, "uSpecularColor");
             GLint locSpecularPower = glGetUniformLocation(shader, "uSpecularPower");
 
@@ -1485,15 +1487,16 @@ namespace SCIRun {
 
             mArrowAttribs.bind();
 
+            //GL(glUniform4f(locSpecularColor, 0.0f, 0.0f, 0.0f, 1.0f));
+            //GL(glUniform4f(locAmbientColor, 0.2f, 0.2f, 0.2f, 1.0f));
+            //GL(glUniform1f(locSpecularPower, 16.0f));
+
             // X Axis (dark)
             {
               glm::mat4 xform = glm::rotate(glm::mat4(1.0f), glm::pi<float>() / 2.0f, glm::vec3(0.0, 1.0, 0.0));
               glm::mat4 finalTrafo = axesTransform * xform;
 
-              GL(glUniform4f(locAmbientColor, 0.1f, 0.01f, 0.01f, 1.0f));
               GL(glUniform4f(locDiffuseColor, 0.25f, 0.0f, 0.0f, 1.0f));
-              GL(glUniform4f(locSpecularColor, 0.0f, 0.0f, 0.0f, 1.0f));
-              GL(glUniform1f(locSpecularPower, 16.0f));
 
               glm::mat4 worldToProj = projection * invCamTrans * finalTrafo;
               const GLfloat* ptr = glm::value_ptr(worldToProj);
@@ -1511,10 +1514,7 @@ namespace SCIRun {
               glm::mat4 xform = glm::rotate(glm::mat4(1.0f), -glm::pi<float>() / 2.0f, glm::vec3(0.0, 1.0, 0.0));
               glm::mat4 finalTrafo = axesTransform * xform;
 
-              GL(glUniform4f(locAmbientColor, 0.5f, 0.01f, 0.01f, 1.0f));
               GL(glUniform4f(locDiffuseColor, 1.0f, 0.0f, 0.0f, 1.0f));
-              GL(glUniform4f(locSpecularColor, 0.5f, 0.5f, 0.5f, 1.0f));
-              GL(glUniform1f(locSpecularPower, 16.0f));
 
               glm::mat4 worldToProj = projection * invCamTrans * finalTrafo;
               const GLfloat* ptr = glm::value_ptr(worldToProj);
@@ -1532,10 +1532,7 @@ namespace SCIRun {
               glm::mat4 xform = glm::rotate(glm::mat4(1.0f), -glm::pi<float>() / 2.0f, glm::vec3(1.0, 0.0, 0.0));
               glm::mat4 finalTrafo = axesTransform * xform;
 
-              GL(glUniform4f(locAmbientColor, 0.01f, 0.1f, 0.01f, 1.0f));
               GL(glUniform4f(locDiffuseColor, 0.0f, 0.25f, 0.0f, 1.0f));
-              GL(glUniform4f(locSpecularColor, 0.0f, 0.0f, 0.0f, 1.0f));
-              GL(glUniform1f(locSpecularPower, 16.0f));
 
               glm::mat4 worldToProj = projection * invCamTrans * finalTrafo;
               const GLfloat* ptr = glm::value_ptr(worldToProj);
@@ -1553,10 +1550,7 @@ namespace SCIRun {
               glm::mat4 xform = glm::rotate(glm::mat4(1.0f), glm::pi<float>() / 2.0f, glm::vec3(1.0, 0.0, 0.0));
               glm::mat4 finalTrafo = axesTransform * xform;
 
-              GL(glUniform4f(locAmbientColor, 0.01f, 0.5f, 0.01f, 1.0f));
               GL(glUniform4f(locDiffuseColor, 0.0f, 1.0f, 0.0f, 1.0f));
-              GL(glUniform4f(locSpecularColor, 0.5f, 0.5f, 0.5f, 1.0f));
-              GL(glUniform1f(locSpecularPower, 16.0f));
 
               glm::mat4 worldToProj = projection * invCamTrans * finalTrafo;
               const GLfloat* ptr = glm::value_ptr(worldToProj);
@@ -1574,10 +1568,7 @@ namespace SCIRun {
               // No rotation at all
               glm::mat4 finalTrafo = axesTransform;
 
-              GL(glUniform4f(locAmbientColor, 0.01f, 0.01f, 0.1f, 1.0f));
               GL(glUniform4f(locDiffuseColor, 0.0f, 0.0f, 0.25f, 1.0f));
-              GL(glUniform4f(locSpecularColor, 0.0f, 0.0f, 0.0f, 1.0f));
-              GL(glUniform1f(locSpecularPower, 16.0f));
 
               glm::mat4 worldToProj = projection * invCamTrans * finalTrafo;
               const GLfloat* ptr = glm::value_ptr(worldToProj);
@@ -1596,10 +1587,7 @@ namespace SCIRun {
               glm::mat4 xform = glm::rotate(glm::mat4(1.0f), glm::pi<float>(), glm::vec3(1.0, 0.0, 0.0));
               glm::mat4 finalTrafo = axesTransform * xform;
 
-              GL(glUniform4f(locAmbientColor, 0.01f, 0.01f, 0.5f, 1.0f));
               GL(glUniform4f(locDiffuseColor, 0.0f, 0.0f, 1.0f, 1.0f));
-              GL(glUniform4f(locSpecularColor, 0.5f, 0.5f, 0.5f, 1.0f));
-              GL(glUniform1f(locSpecularPower, 16.0f));
 
               glm::mat4 worldToProj = projection * invCamTrans * finalTrafo;
               const GLfloat* ptr = glm::value_ptr(worldToProj);

--- a/src/Interface/Modules/Render/ES/SRInterface.h
+++ b/src/Interface/Modules/Render/ES/SRInterface.h
@@ -168,8 +168,10 @@ namespace SCIRun {
       //---------------- Rendering -----------------------------------------------------------------
       void doFrame(double currentTime, double constantDeltaTime); // Performs a frame.
       void setLightColor(int index, float r, float g, float b);
-      void setLightPosition(int index, float x, float y);
       void setLightOn(int index, bool value);
+      void setLightAzimuth(int index, float azimuth);
+      void setLightInclination(int index, float inclination);
+      void updateLightDirection(int index);
       void setMaterialFactor(MatFactor factor, double value);
       void setFog(FogFactor factor, double value);
       void setOrientSize(int size) {orientSize = size/10.0f;}      //Remap 1:100 to 0.1:10
@@ -343,7 +345,8 @@ namespace SCIRun {
       glm::vec4                         mFogColor           {0.0, 0.0, 0.0, 0.0};
 
       //light settings
-      std::vector<glm::vec3>            mLightPosition      {};
+      std::vector<glm::vec2>            mLightDirectionPolar{};
+      std::vector<glm::vec3>            mLightDirectionView{};
       std::vector<bool>                 mLightsOn           {};
 
       const int                         frameInitLimit_     {};

--- a/src/Interface/Modules/Render/ES/shaders/DirPhong.fs
+++ b/src/Interface/Modules/Render/ES/shaders/DirPhong.fs
@@ -25,9 +25,9 @@
    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
    DEALINGS IN THE SOFTWARE.
 */
+
 #ifdef OPENGL_ES
   #ifdef GL_FRAGMENT_PRECISION_HIGH
-    // Default precision
     precision highp float;
   #else
     precision mediump float;
@@ -77,22 +77,13 @@ varying vec4    vFogCoord;          // for fog calculation
 
 vec4 calculate_lighting(vec3 lightDirWorld, vec3 lightColor)
 {
-  // Remember to always negate the light direction for these lighting calculations.
   vec3  invLightDir = -lightDirWorld;
   vec3  normal      = normalize(vNormal);
 
-  // Note, the following is a hack due to legacy meshes still being supported.
-  // We light the object as if it was double sided. We choose the normal based
-  // on the normal that yields the largest diffuse component.
-  float diffuse     = max(0.0, dot(normal, invLightDir));
-  float diffuseInv  = max(0.0, dot(-normal, invLightDir));
-
-  if (diffuse < diffuseInv)
-  {
-    diffuse = diffuseInv;
+  if (gl_FrontFacing)
     normal = -normal;
-  }
 
+  float diffuse     = max(0.0, dot(normal, invLightDir));
   vec3  reflection  = reflect(invLightDir, normal);
   float specular    = max(0.0, dot(reflection, uCamViewVec));
   specular          = pow(specular, uSpecularPower);

--- a/src/Interface/Modules/Render/ES/shaders/DirPhongInSitu.fs
+++ b/src/Interface/Modules/Render/ES/shaders/DirPhongInSitu.fs
@@ -25,9 +25,9 @@
    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
    DEALINGS IN THE SOFTWARE.
 */
+
 #ifdef OPENGL_ES
   #ifdef GL_FRAGMENT_PRECISION_HIGH
-    // Default precision
     precision highp float;
   #else
     precision mediump float;
@@ -37,7 +37,7 @@
 uniform vec3    uCamViewVec;        // Camera 'at' vector in world space
 uniform vec4    uAmbientColor;      // Ambient color
 uniform vec4    uDiffuseColor;      // Diffuse color
-uniform vec4    uSpecularColor;     // Specular color     
+uniform vec4    uSpecularColor;     // Specular color
 uniform float   uSpecularPower;     // Specular power
 uniform vec3    uLightDirWorld;     // Directional light (world space).
 uniform float   uTransparency;
@@ -115,32 +115,21 @@ void main()
       discard;
   }
 
-  // Remember to always negate the light direction for these lighting
-  // calculations. The dot product takes on its greatest values when the angle
-  // between the two vectors diminishes.
   vec3  invLightDir = -uLightDirWorld;
   vec3  normal      = normalize(vNormal);
-  float diffuse     = max(0.0, dot(normal, invLightDir));
 
-  // Note, the following is a hack due to legacy meshes still being supported.
-  // We light the object as if it was double sided. We choose the normal based
-  // on the normal that yields the largest diffuse component.
-  float diffuseInv  = max(0.0, dot(-normal, invLightDir));
-
-  if (diffuse < diffuseInv)
-  {
-    diffuse = diffuseInv;
+  if (gl_FrontFacing)
     normal = -normal;
-  }
 
+  float diffuse     = max(0.0, dot(normal, invLightDir));
   vec3  reflection  = reflect(invLightDir, normal);
-  float spec        = max(0.0, dot(reflection, uCamViewVec));
+  float specular    = max(0.0, dot(reflection, uCamViewVec));
+  specular          = pow(specular, uSpecularPower);
 
   vec4 diffuseColor = vColor;
 
-  spec              = pow(spec, uSpecularPower);
-  gl_FragColor      = vec4((diffuse * spec * uSpecularColor + diffuse * diffuseColor + uAmbientColor).rgb, uTransparency);
-                       
+  gl_FragColor      = vec4((specular * uSpecularColor + diffuse * diffuseColor + uAmbientColor *  diffuseColor).rgb, uTransparency);
+
   //calculate fog
   if (uFogSettings.x > 0.0)
   {
@@ -149,7 +138,7 @@ void main()
     fp.y = uFogSettings.y;
     fp.z = uFogSettings.z;
     fp.w = abs(vFogCoord.z/vFogCoord.w);
-    
+
     float fog_factor;
     fog_factor = (fp.z-fp.w)/(fp.z-fp.y);
     fog_factor = 1.0 - clamp(fog_factor, 0.0, 1.0);
@@ -158,4 +147,3 @@ void main()
       clamp(uFogColor.xyz, 0.0, 1.0), fog_factor);
   }
 }
-

--- a/src/Interface/Modules/Render/ES/shaders/DirPhongNoClipping.fs
+++ b/src/Interface/Modules/Render/ES/shaders/DirPhongNoClipping.fs
@@ -25,9 +25,9 @@
    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
    DEALINGS IN THE SOFTWARE.
 */
+
 #ifdef OPENGL_ES
   #ifdef GL_FRAGMENT_PRECISION_HIGH
-    // Default precision
     precision highp float;
   #else
     precision mediump float;
@@ -37,7 +37,7 @@
 uniform vec3    uCamViewVec;        // Camera 'at' vector in world space
 uniform vec4    uAmbientColor;      // Ambient color
 uniform vec4    uDiffuseColor;      // Diffuse color
-uniform vec4    uSpecularColor;     // Specular color     
+uniform vec4    uSpecularColor;     // Specular color
 uniform float   uSpecularPower;     // Specular power
 uniform vec3    uLightDirWorld;     // Directional light (world space).
 uniform float   uTransparency;
@@ -49,29 +49,16 @@ varying vec3  vNormal;
 
 void main()
 {
-  // Remember to always negate the light direction for these lighting
-  // calculations. The dot product takes on its greatest values when the angle
-  // between the two vectors diminishes.
   vec3  invLightDir = -uLightDirWorld;
-  vec3  normal      = normalize(vNormal);
-  float diffuse     = max(0.0, dot(normal, invLightDir));
+  vec3  normal      = -normalize(vNormal);
 
-  // Note, the following is a hack due to legacy meshes still being supported.
-  // We light the object as if it was double sided. We choose the normal based
-  // on the normal that yields the largest diffuse component.
-  float diffuseInv  = max(0.0, dot(-normal, invLightDir));
-
-  if (diffuse < diffuseInv)
-  {
-    diffuse = diffuseInv;
+  if (gl_FrontFacing)
     normal = -normal;
-  }
 
+  float diffuse     = max(0.0, dot(normal, invLightDir));
   vec3  reflection  = reflect(invLightDir, normal);
-  float spec        = max(0.0, dot(reflection, uCamViewVec));
+  float specular    = max(0.0, dot(reflection, uCamViewVec));
+  specular          = pow(specular, uSpecularPower);
 
-  spec              = pow(spec, uSpecularPower);
-  gl_FragColor      = vec4((diffuse * spec * uSpecularColor + 
-                       diffuse * uDiffuseColor + uAmbientColor).rgb, uTransparency);
+  gl_FragColor      = vec4((specular * uSpecularColor + diffuse * uDiffuseColor + uAmbientColor * uDiffuseColor).rgb, uTransparency);
 }
-

--- a/src/Interface/Modules/Render/ViewScene.cc
+++ b/src/Interface/Modules/Render/ViewScene.cc
@@ -475,19 +475,39 @@ void ViewSceneDialog::setInitialLightValues()
 {
   auto light0str = state_->getValue(Modules::Render::ViewScene::HeadLightColor).toString();
   QColor light0 = checkColorSetting(light0str, Qt::white);
+  int headlightAzimuth = state_->getValue(Modules::Render::ViewScene::HeadLightAzimuth).toInt();
+  int headlightInclination = state_->getValue(Modules::Render::ViewScene::HeadLightInclination).toInt();
 
   auto light1str = state_->getValue(Modules::Render::ViewScene::Light1Color).toString();
   QColor light1 = checkColorSetting(light1str, Qt::white);
+  int light1Azimuth = state_->getValue(Modules::Render::ViewScene::Light1Azimuth).toInt();
+  int light1Inclination = state_->getValue(Modules::Render::ViewScene::Light1Inclination).toInt();
 
   auto light2str = state_->getValue(Modules::Render::ViewScene::Light2Color).toString();
   QColor light2 = checkColorSetting(light2str, Qt::white);
+  int light2Azimuth = state_->getValue(Modules::Render::ViewScene::Light2Azimuth).toInt();
+  int light2Inclination = state_->getValue(Modules::Render::ViewScene::Light2Inclination).toInt();
 
   auto light3str = state_->getValue(Modules::Render::ViewScene::Light3Color).toString();
   QColor light3 = checkColorSetting(light3str, Qt::white);
+  int light3Azimuth = state_->getValue(Modules::Render::ViewScene::Light2Azimuth).toInt();
+  int light3Inclination = state_->getValue(Modules::Render::ViewScene::Light2Inclination).toInt();
 
   auto spire = mSpire.lock();
   if (spire)
   {
+    setHeadLightAzimuth(headlightAzimuth);
+    setHeadLightInclination(headlightInclination);
+
+    setLight1Azimuth(light1Azimuth);
+    setLight1Inclination(light1Inclination);
+
+    setLight2Azimuth(light2Azimuth);
+    setLight2Inclination(light2Inclination);
+
+    setLight3Azimuth(light3Azimuth);
+    setLight3Inclination(light3Inclination);
+
     spire->setLightColor(0, light0.redF(), light0.greenF(), light0.blueF());
     spire->setLightColor(1, light1.redF(), light1.greenF(), light1.blueF());
     spire->setLightColor(2, light2.redF(), light2.greenF(), light2.blueF());
@@ -1604,14 +1624,6 @@ GeometryHandle ViewSceneDialog::buildGeometryScaleBar()
 //--------------------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------------------
-void ViewSceneDialog::setLightPosition(int index)
-{
-  auto spire = mSpire.lock();
-  if (spire)
-    spire->setLightPosition(index, mConfigurationDock->getLightPosition(index).x(), mConfigurationDock->getLightPosition(index).y());
-}
-
-//--------------------------------------------------------------------------------------------------
 void ViewSceneDialog::setLightColor(int index)
 {
   QColor lightColor(mConfigurationDock->getLightColor(index));
@@ -1644,10 +1656,44 @@ void ViewSceneDialog::toggleHeadLight(bool value)
   toggleLightOnOff(0, value);
 }
 
+const static float PI = 3.1415926f;
+
+//--------------------------------------------------------------------------------------------------
+void ViewSceneDialog::setHeadLightAzimuth(int value)
+{
+  state_->setValue(Modules::Render::ViewScene::HeadLightAzimuth, value);
+  auto spire = mSpire.lock();
+  spire->setLightAzimuth(0, value / 180.0f * PI - PI);
+}
+
+//--------------------------------------------------------------------------------------------------
+void ViewSceneDialog::setHeadLightInclination(int value)
+{
+  state_->setValue(Modules::Render::ViewScene::HeadLightInclination, value);
+  auto spire = mSpire.lock();
+  spire->setLightInclination(0, value / 180.0f * PI - PI / 2.0f);
+}
+
 //--------------------------------------------------------------------------------------------------
 void ViewSceneDialog::toggleLight1(bool value)
 {
   toggleLightOnOff(1, value);
+}
+
+//--------------------------------------------------------------------------------------------------
+void ViewSceneDialog::setLight1Azimuth(int value)
+{
+  state_->setValue(Modules::Render::ViewScene::Light1Azimuth, value);
+  auto spire = mSpire.lock();
+  spire->setLightAzimuth(1, value / 180.0f * PI - PI);
+}
+
+//--------------------------------------------------------------------------------------------------
+void ViewSceneDialog::setLight1Inclination(int value)
+{
+  state_->setValue(Modules::Render::ViewScene::Light1Inclination, value);
+  auto spire = mSpire.lock();
+  spire->setLightInclination(1, value / 180.0f * PI - PI / 2.0f);
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1657,9 +1703,41 @@ void ViewSceneDialog::toggleLight2(bool value)
 }
 
 //--------------------------------------------------------------------------------------------------
+void ViewSceneDialog::setLight2Azimuth(int value)
+{
+  state_->setValue(Modules::Render::ViewScene::Light2Azimuth, value);
+  auto spire = mSpire.lock();
+  spire->setLightAzimuth(2, value / 180.0f * PI - PI);
+}
+
+//--------------------------------------------------------------------------------------------------
+void ViewSceneDialog::setLight2Inclination(int value)
+{
+  state_->setValue(Modules::Render::ViewScene::Light2Inclination, value);
+  auto spire = mSpire.lock();
+  spire->setLightInclination(2, value / 180.0f * PI - PI / 2.0f);
+}
+
+//--------------------------------------------------------------------------------------------------
 void ViewSceneDialog::toggleLight3(bool value)
 {
   toggleLightOnOff(3, value);
+}
+
+//--------------------------------------------------------------------------------------------------
+void ViewSceneDialog::setLight3Azimuth(int value)
+{
+  state_->setValue(Modules::Render::ViewScene::Light3Azimuth, value);
+  auto spire = mSpire.lock();
+  spire->setLightAzimuth(3, value / 180.0f * PI - PI);
+}
+
+//--------------------------------------------------------------------------------------------------
+void ViewSceneDialog::setLight3Inclination(int value)
+{
+  state_->setValue(Modules::Render::ViewScene::Light3Inclination, value);
+  auto spire = mSpire.lock();
+  spire->setLightInclination(3, value / 180.0f * PI - PI / 2.0f);
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1695,6 +1773,11 @@ void ViewSceneDialog::toggleLightOnOff(int index, bool value)
 }
 
 
+
+void ViewSceneDialog::updateLightDirection(int light)
+{
+
+}
 
 //--------------------------------------------------------------------------------------------------
 //---------------- Materials -----------------------------------------------------------------------

--- a/src/Interface/Modules/Render/ViewScene.h
+++ b/src/Interface/Modules/Render/ViewScene.h
@@ -137,12 +137,20 @@ namespace SCIRun {
       void setScaleBar();
 
       //---------------- Lights --------------------------------------------------------------------
-      void setLightPosition(int index);
       void setLightColor(int index);
       void toggleHeadLight(bool value);
+      void setHeadLightAzimuth(int value);
+      void setHeadLightInclination(int value);
       void toggleLight1(bool value);
+      void setLight1Azimuth(int value);
+      void setLight1Inclination(int value);
       void toggleLight2(bool value);
+      void setLight2Azimuth(int value);
+      void setLight2Inclination(int value);
       void toggleLight3(bool value);
+      void setLight3Azimuth(int value);
+      void setLight3Inclination(int value);
+      void updateLightDirection(int light);
       void lightingChecked(bool value);
 
       //---------------- Material Settings ---------------------------------------------------------

--- a/src/Interface/Modules/Render/ViewSceneControls.ui
+++ b/src/Interface/Modules/Render/ViewSceneControls.ui
@@ -39,7 +39,7 @@
        </font>
       </property>
       <property name="currentIndex">
-       <number>5</number>
+       <number>3</number>
       </property>
       <widget class="QWidget" name="ObjectTab">
        <attribute name="title">
@@ -754,72 +754,7 @@
         <string>Lights</string>
        </attribute>
        <layout class="QGridLayout" name="gridLayout_14">
-        <item row="0" column="0">
-         <widget class="QFrame" name="headlightFrame_">
-          <property name="minimumSize">
-           <size>
-            <width>201</width>
-            <height>115</height>
-           </size>
-          </property>
-          <property name="frameShape">
-           <enum>QFrame::StyledPanel</enum>
-          </property>
-          <property name="frameShadow">
-           <enum>QFrame::Raised</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QFrame" name="light1Frame_">
-          <property name="minimumSize">
-           <size>
-            <width>201</width>
-            <height>115</height>
-           </size>
-          </property>
-          <property name="frameShape">
-           <enum>QFrame::StyledPanel</enum>
-          </property>
-          <property name="frameShadow">
-           <enum>QFrame::Raised</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="headlightCheckBox_">
-          <property name="text">
-           <string>Headlight: on/off</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QCheckBox" name="light1CheckBox_">
-          <property name="text">
-           <string>Light1: on/off</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QFrame" name="light2Frame_">
-          <property name="minimumSize">
-           <size>
-            <width>201</width>
-            <height>115</height>
-           </size>
-          </property>
-          <property name="frameShape">
-           <enum>QFrame::StyledPanel</enum>
-          </property>
-          <property name="frameShadow">
-           <enum>QFrame::Raised</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
+        <item row="4" column="1">
          <widget class="QFrame" name="light3Frame_">
           <property name="minimumSize">
            <size>
@@ -835,34 +770,103 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
-         <widget class="QCheckBox" name="light2CheckBox_">
-          <property name="text">
-           <string>Light2: on/off</string>
+        <item row="2" column="1">
+         <widget class="QSlider" name="light1AzimuthSlider_">
+          <property name="maximum">
+           <number>360</number>
           </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QCheckBox" name="light3CheckBox_">
-          <property name="text">
-           <string>Light3: on/off</string>
+          <property name="value">
+           <number>180</number>
           </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <spacer name="verticalSpacer_6">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Horizontal</enum>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>29</height>
-           </size>
-          </property>
-         </spacer>
+         </widget>
         </item>
-        <item row="5" column="0" colspan="2">
+        <item row="7" column="0">
+         <widget class="QSlider" name="light2AzimuthSlider_">
+          <property name="maximum">
+           <number>360</number>
+          </property>
+          <property name="value">
+           <number>180</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="11" column="0" colspan="2">
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item>
+           <spacer name="horizontalSpacer_12">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>172</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_25">
+            <property name="text">
+             <string>Click on circle to change light color/brightness</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_16">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>171</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item row="8" column="0">
+         <widget class="QSlider" name="light2InclinationSlider_">
+          <property name="maximum">
+           <number>180</number>
+          </property>
+          <property name="value">
+           <number>90</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QCheckBox" name="light1CheckBox_">
+          <property name="text">
+           <string>Light1: on/off</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="1">
+         <widget class="QSlider" name="light3AzimuthSlider_">
+          <property name="maximum">
+           <number>360</number>
+          </property>
+          <property name="value">
+           <number>180</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="0" colspan="2">
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
            <spacer name="horizontalSpacer_7">
@@ -899,42 +903,142 @@
           </item>
          </layout>
         </item>
-        <item row="6" column="0" colspan="2">
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <item>
-           <spacer name="horizontalSpacer_12">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>172</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QLabel" name="label_25">
-            <property name="text">
-             <string>Click on circle to change light color/brightness</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_16">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>171</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
+        <item row="9" column="1">
+         <spacer name="verticalSpacer_6">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>29</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="8" column="1">
+         <widget class="QSlider" name="light3InclinationSlider_">
+          <property name="maximum">
+           <number>180</number>
+          </property>
+          <property name="value">
+           <number>90</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QFrame" name="headlightFrame_">
+          <property name="minimumSize">
+           <size>
+            <width>201</width>
+            <height>115</height>
+           </size>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::StyledPanel</enum>
+          </property>
+          <property name="frameShadow">
+           <enum>QFrame::Raised</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QCheckBox" name="light2CheckBox_">
+          <property name="text">
+           <string>Light2: on/off</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QSlider" name="light1InclinationSlider_">
+          <property name="maximum">
+           <number>180</number>
+          </property>
+          <property name="value">
+           <number>90</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QFrame" name="light2Frame_">
+          <property name="minimumSize">
+           <size>
+            <width>201</width>
+            <height>115</height>
+           </size>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::StyledPanel</enum>
+          </property>
+          <property name="frameShadow">
+           <enum>QFrame::Raised</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QCheckBox" name="light3CheckBox_">
+          <property name="text">
+           <string>Light3: on/off</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QFrame" name="light1Frame_">
+          <property name="minimumSize">
+           <size>
+            <width>201</width>
+            <height>115</height>
+           </size>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::StyledPanel</enum>
+          </property>
+          <property name="frameShadow">
+           <enum>QFrame::Raised</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="headlightCheckBox_">
+          <property name="text">
+           <string>Headlight: on/off</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QSlider" name="headlightInclinationSlider_">
+          <property name="maximum">
+           <number>180</number>
+          </property>
+          <property name="value">
+           <number>90</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QSlider" name="headlightAzimuthSlider_">
+          <property name="maximum">
+           <number>360</number>
+          </property>
+          <property name="value">
+           <number>180</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>

--- a/src/Interface/Modules/Render/ViewSceneControlsDock.cc
+++ b/src/Interface/Modules/Render/ViewSceneControlsDock.cc
@@ -134,7 +134,6 @@ ViewSceneControlsDock::ViewSceneControlsDock(const QString& name, ViewSceneDialo
   connect(orientCenterPositionButton, SIGNAL(clicked()), parent, SLOT(setCenterOrientPos()));
   connect(orientDefaultPositionButton, SIGNAL(clicked()), this, SLOT(setSliderDefaultPos()));
   connect(orientCenterPositionButton, SIGNAL(clicked()), this, SLOT(setSliderCenterPos()));
-  connect(showAxisCheckBox_, SIGNAL(clicked(bool)), parent, SLOT(showAxisChecked(bool)));
   connect(showScaleBarTextGroupBox_, SIGNAL(clicked(bool)), parent, SLOT(setScaleBarVisible(bool)));
   connect(fontSizeSpinBox_, SIGNAL(valueChanged(int)), parent, SLOT(setScaleBarFontSize(int)));
   connect(scaleBarLengthDoubleSpinBox_, SIGNAL(valueChanged(double)), parent, SLOT(setScaleBarLength(double)));
@@ -201,11 +200,9 @@ ViewSceneControlsDock::ViewSceneControlsDock(const QString& name, ViewSceneDialo
   viewOptionsGroupBox_->setVisible(false);
   autoViewOnLoadCheckBox_->setVisible(false);
   orthoViewCheckBox_->setVisible(false);
-  showAxisCheckBox_->setVisible(false);
 
   ////Controls Tab
   transparencyGroupBox_->setVisible(false);
-
 }
 
 void ViewSceneControlsDock::setSampleColor(const QColor& color)

--- a/src/Interface/Modules/Render/ViewSceneControlsDock.cc
+++ b/src/Interface/Modules/Render/ViewSceneControlsDock.cc
@@ -108,9 +108,21 @@ ViewSceneControlsDock::ViewSceneControlsDock(const QString& name, ViewSceneDialo
   connect(dValueHorizontalSlider_, SIGNAL(valueChanged(int)), parent, SLOT(setClippingPlaneD(int)));
   //-----------Lights Tab-----------------//
   connect(headlightCheckBox_, SIGNAL(clicked(bool)), parent, SLOT(toggleHeadLight(bool)));
+  connect(headlightAzimuthSlider_, SIGNAL(valueChanged(int)), parent, SLOT(setHeadLightAzimuth(int)));
+  connect(headlightInclinationSlider_, SIGNAL(valueChanged(int)), parent, SLOT(setHeadLightInclination(int)));
+
   connect(light1CheckBox_, SIGNAL(clicked(bool)), parent, SLOT(toggleLight1(bool)));
+  connect(light1AzimuthSlider_, SIGNAL(valueChanged(int)), parent, SLOT(setLight1Azimuth(int)));
+  connect(light1InclinationSlider_, SIGNAL(valueChanged(int)), parent, SLOT(setLight1Inclination(int)));
+
   connect(light2CheckBox_, SIGNAL(clicked(bool)), parent, SLOT(toggleLight2(bool)));
+  connect(light2AzimuthSlider_, SIGNAL(valueChanged(int)), parent, SLOT(setLight2Azimuth(int)));
+  connect(light2InclinationSlider_, SIGNAL(valueChanged(int)), parent, SLOT(setLight2Inclination(int)));
+
   connect(light3CheckBox_, SIGNAL(clicked(bool)), parent, SLOT(toggleLight3(bool)));
+  connect(light3AzimuthSlider_, SIGNAL(valueChanged(int)), parent, SLOT(setLight3Azimuth(int)));
+  connect(light3InclinationSlider_, SIGNAL(valueChanged(int)), parent, SLOT(setLight3Inclination(int)));
+
   //-----------Materials Tab-----------------//
   connect(ambientDoubleSpinBox_, SIGNAL(valueChanged(double)), parent, SLOT(setAmbientValue(double)));
   connect(diffuseDoubleSpinBox_, SIGNAL(valueChanged(double)), parent, SLOT(setDiffuseValue(double)));
@@ -167,7 +179,7 @@ ViewSceneControlsDock::ViewSceneControlsDock(const QString& name, ViewSceneDialo
 
   for (auto &light : lightControls_)
   {
-    connect(light, SIGNAL(lightMoved(int)), parent, SLOT(setLightPosition(int)));
+    //connect(light, SIGNAL(lightMoved(int)), parent, SLOT(setLightPosition(int)));
     connect(light, SIGNAL(colorChanged(int)), parent, SLOT(setLightColor(int)));
   }
 

--- a/src/Modules/Render/ViewScene.cc
+++ b/src/Modules/Render/ViewScene.cc
@@ -108,6 +108,14 @@ void ViewScene::setStateDefaults()
   state->setValue(Light1Color, ColorRGB(0.0, 0.0, 0.0).toString());
   state->setValue(Light2Color, ColorRGB(0.0, 0.0, 0.0).toString());
   state->setValue(Light3Color, ColorRGB(0.0, 0.0, 0.0).toString());
+  state->setValue(HeadLightAzimuth, 180);
+  state->setValue(Light1Azimuth, 180);
+  state->setValue(Light2Azimuth, 180);
+  state->setValue(Light3Azimuth, 180);
+  state->setValue(HeadLightInclination, 90);
+  state->setValue(Light1Inclination, 90);
+  state->setValue(Light2Inclination, 90);
+  state->setValue(Light3Inclination, 90);
   state->setValue(ShowViewer, false);
 
   get_state()->connectSpecificStateChanged(Parameters::GeometryFeedbackInfo, [this]() { processViewSceneObjectFeedback(); });
@@ -321,4 +329,12 @@ const AlgorithmParameterName ViewScene::HeadLightColor("HeadLightColor");
 const AlgorithmParameterName ViewScene::Light1Color("Light1Color");
 const AlgorithmParameterName ViewScene::Light2Color("Light2Color");
 const AlgorithmParameterName ViewScene::Light3Color("Light3Color");
+const AlgorithmParameterName ViewScene::HeadLightAzimuth("HeadLightAzimuth");
+const AlgorithmParameterName ViewScene::Light1Azimuth("Light1Azimuth");
+const AlgorithmParameterName ViewScene::Light2Azimuth("Light2Azimuth");
+const AlgorithmParameterName ViewScene::Light3Azimuth("Light3Azimuth");
+const AlgorithmParameterName ViewScene::HeadLightInclination("HeadLightInclination");
+const AlgorithmParameterName ViewScene::Light1Inclination("Light1Inclination");
+const AlgorithmParameterName ViewScene::Light2Inclination("Light2Inclination");
+const AlgorithmParameterName ViewScene::Light3Inclination("Light3Inclination");
 const AlgorithmParameterName ViewScene::ShowViewer("ShowViewer");

--- a/src/Modules/Render/ViewScene.h
+++ b/src/Modules/Render/ViewScene.h
@@ -118,6 +118,14 @@ namespace Render {
     static const Core::Algorithms::AlgorithmParameterName Light1Color;
     static const Core::Algorithms::AlgorithmParameterName Light2Color;
     static const Core::Algorithms::AlgorithmParameterName Light3Color;
+    static const Core::Algorithms::AlgorithmParameterName HeadLightAzimuth;
+    static const Core::Algorithms::AlgorithmParameterName Light1Azimuth;
+    static const Core::Algorithms::AlgorithmParameterName Light2Azimuth;
+    static const Core::Algorithms::AlgorithmParameterName Light3Azimuth;
+    static const Core::Algorithms::AlgorithmParameterName HeadLightInclination;
+    static const Core::Algorithms::AlgorithmParameterName Light1Inclination;
+    static const Core::Algorithms::AlgorithmParameterName Light2Inclination;
+    static const Core::Algorithms::AlgorithmParameterName Light3Inclination;
     static const Core::Algorithms::AlgorithmParameterName ShowViewer;
 
 


### PR DESCRIPTION
This resolves issue #1928 allowing us to move on to implement moveable lights. It also switches the orientation glyph to use uniform shading and fixes the vertex ordering for the sphere glyph.

Double sided lighting before:
![image](https://user-images.githubusercontent.com/28606560/57734279-cb38a000-765e-11e9-8b86-02c1fbb682fd.png)

Double sided lighting after:
![image](https://user-images.githubusercontent.com/28606560/57734258-c1af3800-765e-11e9-93ea-6858153530bb.png)


