### PR TITLE
Show Field Glyphs: Secondary and Tertiary Port fix

### DIFF
--- a/src/Modules/Visualization/ShowFieldGlyphsPortHandler.cc
+++ b/src/Modules/Visualization/ShowFieldGlyphsPortHandler.cc
@@ -326,11 +326,19 @@ namespace SCIRun{
                   {
                     throw std::invalid_argument("Secondary Field and Color Map input is required.");
                   }
+                if(s_vfld->num_values() < p_vfld->num_values())
+                  {
+                    throw std::invalid_argument("Secondary Field input cannot have a smaller size than the Primary Field input.");
+                  }
                 break;
               case RenderState::InputPort::TERTIARY_PORT:
                 if(!(tertiaryFieldGiven && colorMap))
                   {
                     throw std::invalid_argument("Tertiary Field and Color Map input is required.");
+                  }
+                if(t_vfld->num_values() < p_vfld->num_values())
+                  {
+                    throw std::invalid_argument("Tertiary Field input cannot have a smaller size than the Primary Field input.");
                   }
                 break;
               }
@@ -351,11 +359,19 @@ namespace SCIRun{
                   {
                     throw std::invalid_argument("Secondary Field input cannot be a scalar for RGB Conversion.");
                   }
+                if(s_vfld->num_values() < p_vfld->num_values())
+                  {
+                    throw std::invalid_argument("Secondary Field input cannot have a smaller size than the Primary Field input.");
+                  }
                 break;
               case RenderState::InputPort::TERTIARY_PORT:
                 if(tf_data_type == FieldDataType::Scalar)
                   {
                     throw std::invalid_argument("Tertiary Field input cannot be a scalar for RGB Conversion.");
+                  }
+                if(t_vfld->num_values() < p_vfld->num_values())
+                  {
+                    throw std::invalid_argument("Tertiary Field input cannot have a smaller size than the Primary Field input.");
                   }
                 break;
               }
@@ -369,11 +385,19 @@ namespace SCIRun{
               {
                 throw std::invalid_argument("Secondary Field input is required for Secondary Vector Parameter.");
               }
+            if(s_vfld->num_values() < p_vfld->num_values())
+              {
+                throw std::invalid_argument("Secondary Field input cannot have a smaller size than the Primary Field input.");
+              }
             break;
           case RenderState::InputPort::TERTIARY_PORT:
             if(!tertiaryFieldGiven)
               {
                 throw std::invalid_argument("Tertiary Field input is required for Secondary Vector Parameter.");
+              }
+            if(t_vfld->num_values() < p_vfld->num_values())
+              {
+                throw std::invalid_argument("Tertiary Field input cannot have a smaller size than the Primary Field input.");
               }
             break;
           }


### PR DESCRIPTION
SCIRun crashed when the secondary/tertiary field port had less elements than the primary field port. Show Field Glyphs now reports an error to the user.

Reviewers:
@jessdtate @dcwhite 

