### PR TITLE
Linux travis qt5 updates

### DIFF
--- a/src/Interface/Application/scirun5.qrc
+++ b/src/Interface/Application/scirun5.qrc
@@ -46,6 +46,7 @@
     <file>Resources/ViewScene/views.png</file>
     <file>Resources/ViewScene/lockView.png</file>
     <file>Resources/ViewScene/screenshot.png</file>
+    <file>Resources/ViewScene/bugReport.png</file>
     <file>Resources/network.png</file>
     <file>Resources/subnet3.png</file>
     <file>Resources/editSubnet.png</file>

--- a/src/Interface/Modules/Render/ViewScene.cc
+++ b/src/Interface/Modules/Render/ViewScene.cc
@@ -204,6 +204,8 @@ void ViewSceneDialog::addToolBar()
   glLayout->addWidget(mToolBar);
 
   addViewBar();
+
+  addBugReportButton();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -297,6 +299,15 @@ void ViewSceneDialog::addScreenshotButton()
   screenshotButton->setShortcut(Qt::Key_F12);
   connect(screenshotButton, SIGNAL(clicked(bool)), this, SLOT(screenshotClicked()));
   addToolbarButton(screenshotButton);
+}
+
+//--------------------------------------------------------------------------------------------------
+void ViewSceneDialog::addBugReportButton() {
+  QPushButton *bugReportButton = new QPushButton(this);
+  bugReportButton->setToolTip("Report a bug");
+  bugReportButton->setIcon(QPixmap(":/general/Resources/ViewScene/bugReport.png"));
+  connect(bugReportButton, SIGNAL(clicked(bool)), this, SLOT(reportBugClicked()));
+  addToolbarButton(bugReportButton);
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -2141,6 +2152,12 @@ void ViewSceneDialog::setTransparencySortTypeLists(bool index)
 //--------------------------------------------------------------------------------------------------
 void ViewSceneDialog::screenshotClicked()
 {
+  takeScreenshot();
+  screenshotTaker_->saveScreenshot();
+}
+
+//--------------------------------------------------------------------------------------------------
+void ViewSceneDialog::reportBugClicked() {
   takeScreenshot();
   screenshotTaker_->saveScreenshot();
 }

--- a/src/Interface/Modules/Render/ViewScene.h
+++ b/src/Interface/Modules/Render/ViewScene.h
@@ -189,6 +189,7 @@ namespace SCIRun {
       void setTransparencySortTypeUpdate(bool index);
       void setTransparencySortTypeLists(bool index);
       void screenshotClicked();
+      void reportBugClicked();
       void saveNewGeometryChanged(int state);
       void showBBoxChecked(bool value);
       void useBackCullChecked(bool value);
@@ -223,6 +224,7 @@ namespace SCIRun {
       void setupRenderTabValues();
       void addAutoViewButton();
       void addScreenshotButton();
+      void addBugReportButton();
       void addViewBarButton();
       void addControlLockButton();
       void addToolbarButton(QPushButton* button);


### PR DESCRIPTION
Sorry, for the duplicate ticket, but I'm limited to 50 minutes on my travis account. Ignore for now. Not ready for merge.

Fixes:
Linux with qt5: clang and gcc

Clang uses old qt5 versions