### PR TITLE
Fixed Compiler Warning for Regex Expression for Camera Rotation

### DIFF
--- a/src/Interface/Modules/Render/ViewSceneUtility.cc
+++ b/src/Interface/Modules/Render/ViewSceneUtility.cc
@@ -41,7 +41,7 @@ glm::quat ViewSceneUtility::stringToQuat(const std::string &s)
   {
     try
     {
-      static boost::regex r("Quaternion\\((.+),\\ ?(.+),\\ ?(.+),\\ ?(.+)\\)");
+      static boost::regex r("Quaternion\\((.+),\\s?(.+),\\s?(.+),\\s?(.+)\\)");
       boost::smatch what;
       regex_match(s, what, r);
       w = boost::lexical_cast<double>(what[1]);

--- a/src/Interface/Modules/Render/ViewSceneUtility.cc
+++ b/src/Interface/Modules/Render/ViewSceneUtility.cc
@@ -41,7 +41,7 @@ glm::quat ViewSceneUtility::stringToQuat(const std::string &s)
   {
     try
     {
-      static boost::regex r("Quaternion\\((.+),\ ?(.+),\ ?(.+),\ ?(.+)\\)");
+      static boost::regex r("Quaternion\\((.+),\\ ?(.+),\\ ?(.+),\\ ?(.+)\\)");
       boost::smatch what;
       regex_match(s, what, r);
       w = boost::lexical_cast<double>(what[1]);


### PR DESCRIPTION
Just a quick fix to get rid of the compiler warning.
