### PR TITLE
Fixes #2167

### DIFF
--- a/src/Interface/Modules/Render/ViewScene.cc
+++ b/src/Interface/Modules/Render/ViewScene.cc
@@ -1773,8 +1773,10 @@ void ViewSceneDialog::buildGeometryClippingPlane(int index, const glm::vec4& pla
   renState.set(RenderState::USE_NORMALS, true);
   renState.set(RenderState::IS_WIDGET, true);
   auto geom(boost::make_shared<GeometryObjectSpire>(*gid_, uniqueNodeID, false));
+  static const BBox invalidDefaultConstructedBoundingBoxRequiredForClippingPlanes; // bug #2167
   glyphs.buildObject(*geom, uniqueNodeID, renState.get(RenderState::USE_TRANSPARENCY), 1.0,
-    colorScheme, renState, SpireIBO::PRIMITIVE::TRIANGLES, BBox(Point{}, Point{}), false, nullptr);
+    colorScheme, renState, SpireIBO::PRIMITIVE::TRIANGLES,
+    invalidDefaultConstructedBoundingBoxRequiredForClippingPlanes, false, nullptr);
 
   Graphics::GlyphGeom glyphs2;
   glyphs2.addPlane(p1, p2, p3, p4, ColorRGB());
@@ -1789,7 +1791,8 @@ void ViewSceneDialog::buildGeometryClippingPlane(int index, const glm::vec4& pla
   renState.defaultColor = ColorRGB(1, 1, 1, 0.2);
   auto geom2(boost::make_shared<GeometryObjectSpire>(*gid_, ss.str(), false));
   glyphs2.buildObject(*geom2, uniqueNodeID, renState.get(RenderState::USE_TRANSPARENCY), 0.2,
-    colorScheme, renState, SpireIBO::PRIMITIVE::TRIANGLES, BBox(Point{}, Point{}), false, nullptr);
+    colorScheme, renState, SpireIBO::PRIMITIVE::TRIANGLES,
+    invalidDefaultConstructedBoundingBoxRequiredForClippingPlanes, false, nullptr);
 
   clippingPlaneGeoms_.push_back(geom);
   clippingPlaneGeoms_.push_back(geom2);


### PR DESCRIPTION
Clipping planes are working again. They require invalid bounding boxes to work.

I'll make an issue to fix the logic and remove the variable `invalidDefaultConstructedBoundingBoxRequiredForClippingPlanes`.