### PR TITLE
Fix performance regression from overuse of interruption checks

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -17,7 +17,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2.9.0
+      uses: jurplel/install-qt-action@v2.13.0
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       with:
@@ -74,7 +74,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2.9.0
+      uses: jurplel/install-qt-action@v2.13.0
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       with:
@@ -116,7 +116,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2.9.0
+      uses: jurplel/install-qt-action@v2.13.0
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -45,7 +45,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2.9.0
+      uses: jurplel/install-qt-action@v2.13.0
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       with:
@@ -90,7 +90,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2.9.0
+      uses: jurplel/install-qt-action@v2.13.0
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       with:
@@ -143,7 +143,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2.9.0
+      uses: jurplel/install-qt-action@v2.13.0
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       with:

--- a/src/Core/Algorithms/Legacy/Fields/DistanceField/CalculateDistanceField.cc
+++ b/src/Core/Algorithms/Legacy/Fields/DistanceField/CalculateDistanceField.cc
@@ -93,7 +93,7 @@ class CalculateDistanceFieldP : public Interruptible
 
         for (VMesh::Elem::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           Point p, p2;
           imesh->get_center(p,idx);
           if(!(objmesh->find_closest_elem(val,p2,fidx,p,max))) val = max;
@@ -110,7 +110,7 @@ class CalculateDistanceFieldP : public Interruptible
 
         for (VMesh::Node::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           Point p, p2;
           imesh->get_center(p,idx);
           if(!(objmesh->find_closest_elem(val,p2,fidx,p,max))) val = max;
@@ -127,7 +127,7 @@ class CalculateDistanceFieldP : public Interruptible
 
         for (VMesh::ENode::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           Point p, p2;
           imesh->get_center(p,idx);
           if(!(objmesh->find_closest_elem(val,p2,fidx,p,max))) val = max;
@@ -166,7 +166,7 @@ class CalculateDistanceFieldP : public Interruptible
 
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             imesh->get_center(p,idx);
             objmesh->find_closest_elem(val,p2,coords,fidx,p);
             ofield->set_value(val,idx);
@@ -181,7 +181,7 @@ class CalculateDistanceFieldP : public Interruptible
 
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             imesh->get_center(p,idx);
             objmesh->find_closest_elem(val,p2,coords,fidx,p);
             ofield->set_value(val,idx);
@@ -196,7 +196,7 @@ class CalculateDistanceFieldP : public Interruptible
 
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             imesh->get_center(p,idx);
             objmesh->find_closest_elem(val,p2,coords,fidx,p);
             ofield->set_value(val,idx);
@@ -220,7 +220,7 @@ class CalculateDistanceFieldP : public Interruptible
 
           for (VMesh::Node::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             imesh->get_center(p,idx);
             objmesh->find_closest_elem(val,p2,coords,fidx,p);
             ofield->set_value(val,idx);
@@ -236,7 +236,7 @@ class CalculateDistanceFieldP : public Interruptible
 
           for (VMesh::Node::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             imesh->get_center(p,idx);
             objmesh->find_closest_elem(val,p2,coords,fidx,p);
             ofield->set_value(val,idx);
@@ -252,7 +252,7 @@ class CalculateDistanceFieldP : public Interruptible
 
           for (VMesh::Node::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             imesh->get_center(p,idx);
             objmesh->find_closest_elem(val,p2,coords,fidx,p);
             ofield->set_value(val,idx);
@@ -276,7 +276,7 @@ class CalculateDistanceFieldP : public Interruptible
           double scalar;
           for (VMesh::ENode::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             imesh->get_center(p,idx);
             objmesh->find_closest_elem(val,p2,coords,fidx,p);
             ofield->set_value(val,idx);
@@ -291,7 +291,7 @@ class CalculateDistanceFieldP : public Interruptible
           Vector vec;
           for (VMesh::ENode::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             imesh->get_center(p,idx);
             objmesh->find_closest_elem(val,p2,coords,fidx,p);
             ofield->set_value(val,idx);
@@ -306,7 +306,7 @@ class CalculateDistanceFieldP : public Interruptible
           Tensor tensor;
           for (VMesh::ENode::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             imesh->get_center(p,idx);
             objmesh->find_closest_elem(val,p2,coords,fidx,p);
             ofield->set_value(val,idx);

--- a/src/Core/Algorithms/Legacy/Fields/DistanceField/CalculateSignedDistanceField.cc
+++ b/src/Core/Algorithms/Legacy/Fields/DistanceField/CalculateSignedDistanceField.cc
@@ -73,7 +73,7 @@ class CalculateSignedDistanceFieldP : public Interruptible
 
         for (VMesh::Elem::index_type idx = start; idx < end; idx++)
         {
-          checkForInterruption(this);
+
           Point p, p1, p2;
           imesh->get_center(p,idx);
 
@@ -140,7 +140,7 @@ class CalculateSignedDistanceFieldP : public Interruptible
               if (angle < 0) val = -(val);
             }
           }
-          checkForInterruption(this);
+
           ofield->set_value(val,idx);
           if (proc == 0) { cnt++; if (cnt == 100) { pr_->update_progress_max(idx,end); cnt = 0; } }
         }
@@ -158,7 +158,7 @@ class CalculateSignedDistanceFieldP : public Interruptible
 
         for (VMesh::Node::index_type idx =start; idx <end; idx++)
         {
-          checkForInterruption();
+
           Point p, p1, p2;
           imesh->get_center(p,idx);
           objmesh->find_closest_elem(val,p2,fidx,p);
@@ -224,7 +224,7 @@ class CalculateSignedDistanceFieldP : public Interruptible
               if (angle < 0.0) val = -(val);
             }
           }
-          checkForInterruption(this);
+
           ofield->set_value(val,idx);
           if (proc == 0) { cnt++; if (cnt == 100) { pr_->update_progress_max(idx,end); cnt = 0; } }
         }
@@ -242,7 +242,7 @@ class CalculateSignedDistanceFieldP : public Interruptible
 
         for (VMesh::ENode::index_type idx=start; idx < end; idx++)
         {
-          checkForInterruption(this);
+
           Point p, p1, p2;
           imesh->get_center(p,idx);
           objmesh->find_closest_elem(val,p2,fidx,p);
@@ -308,7 +308,7 @@ class CalculateSignedDistanceFieldP : public Interruptible
               if (angle < 0.0) val = -(val);
             }
           }
-          checkForInterruption(this);
+
           ofield->set_evalue(val,idx);
           if (proc == 0) { cnt++; if (cnt == 100) { pr_->update_progress_max(idx,end); cnt = 0; } }
         }
@@ -338,7 +338,7 @@ class CalculateSignedDistanceFieldP : public Interruptible
 
         for (VMesh::Elem::index_type idx = start; idx < end; idx++)
         {
-          checkForInterruption(this);
+
           Point p, p1, p2;
           imesh->get_center(p,idx);
 
@@ -405,7 +405,7 @@ class CalculateSignedDistanceFieldP : public Interruptible
               if (angle < 0) val = -(val);
             }
           }
-          checkForInterruption(this);
+
           ofield->set_value(val,idx);
           if (objfield->is_scalar())
           {
@@ -442,7 +442,7 @@ class CalculateSignedDistanceFieldP : public Interruptible
 
         for (VMesh::Node::index_type idx =start; idx <end; idx++)
         {
-          checkForInterruption(this);
+
           Point p, p1, p2;
           imesh->get_center(p,idx);
           objmesh->find_closest_elem(val,p2,coords,fidx,p);
@@ -509,7 +509,7 @@ class CalculateSignedDistanceFieldP : public Interruptible
               if (angle < 0.0) val = -(val);
             }
           }
-          checkForInterruption(this);
+
           ofield->set_value(val,idx);
           if (objfield->is_scalar())
           {
@@ -546,7 +546,7 @@ class CalculateSignedDistanceFieldP : public Interruptible
 
         for (VMesh::ENode::index_type idx=start; idx < end; idx++)
         {
-          checkForInterruption(this);
+
           Point p, p1, p2;
           imesh->get_center(p,idx);
           objmesh->find_closest_elem(val,p2,coords,fidx,p);
@@ -612,7 +612,7 @@ class CalculateSignedDistanceFieldP : public Interruptible
               if (angle < 0.0) val = -(val);
             }
           }
-          checkForInterruption(this);
+
           ofield->set_evalue(val,idx);
           if (objfield->is_scalar())
           {

--- a/src/Core/Algorithms/Legacy/Fields/DomainFields/GetDomainBoundaryAlgo.cc
+++ b/src/Core/Algorithms/Legacy/Fields/DomainFields/GetDomainBoundaryAlgo.cc
@@ -219,7 +219,7 @@ GetDomainBoundaryAlgo::runImpl(FieldHandle input, SparseRowMatrixHandle domainli
 
     for(VMesh::DElem::index_type delem = 0; delem < numdelems; ++delem)
     {
-      checkForInterruption(this);
+
 
       bool neighborexist = false;
       bool includeface = false;
@@ -332,7 +332,7 @@ GetDomainBoundaryAlgo::runImpl(FieldHandle input, SparseRowMatrixHandle domainli
         onodes.resize(inodes.size());
         for (size_t q=0; q< onodes.size(); q++)
         {
-          checkForInterruption(this);
+
           a = inodes[q];
 
           std::pair<pointhash_map_type::iterator,pointhash_map_type::iterator> lit;
@@ -406,7 +406,7 @@ GetDomainBoundaryAlgo::runImpl(FieldHandle input, SparseRowMatrixHandle domainli
 
     for(VMesh::DElem::index_type delem = 0; delem < numdelems; ++delem)
     {
-      checkForInterruption(this);
+
 
       bool neighborexist = false;
       bool includeface = false;
@@ -516,7 +516,7 @@ GetDomainBoundaryAlgo::runImpl(FieldHandle input, SparseRowMatrixHandle domainli
 
         for (size_t q=0; q< onodes.size(); q++)
         {
-          checkForInterruption(this);
+
           a = inodes[q];
           if (node_map[a] == -1)
           {

--- a/src/Core/Algorithms/Legacy/Fields/Mapping/MapFieldDataFromElemToNode.cc
+++ b/src/Core/Algorithms/Legacy/Fields/Mapping/MapFieldDataFromElemToNode.cc
@@ -86,7 +86,7 @@ bool
   {
     while (it != eit)
     {
-      checkForInterruption(algo);
+
       mesh->get_elems(elems, *(it));
       size_t nsize = elems.size();
       DATA val(0);
@@ -111,7 +111,7 @@ bool
   {
     while (it != eit)
     {
-      checkForInterruption(algo);
+
       mesh->get_elems(elems, *(it));
       size_t nsize = elems.size();
       DATA val(0);
@@ -139,7 +139,7 @@ bool
   {
     while (it != eit)
     {
-      checkForInterruption(algo);
+
       mesh->get_elems(elems, *it);
       size_t nsize = elems.size();
       DATA val(0);
@@ -167,7 +167,7 @@ bool
   {
     while (it != eit)
     {
-      checkForInterruption(algo);
+
       mesh->get_elems(elems, *(it));
       size_t nsize = elems.size();
       DATA val(0);
@@ -192,7 +192,7 @@ bool
     std::vector<DATA> valarray;
     while (it != eit)
     {
-      checkForInterruption(algo);
+
       mesh->get_elems(elems, *(it));
       size_t nsize = elems.size();
       valarray.resize(nsize);

--- a/src/Core/Algorithms/Legacy/Fields/Mapping/MapFieldDataFromNodeToElem.cc
+++ b/src/Core/Algorithms/Legacy/Fields/Mapping/MapFieldDataFromNodeToElem.cc
@@ -85,7 +85,7 @@ MapFieldDataFromNodeToElemT(const MapFieldDataFromNodeToElemAlgo* algo,
     DATA tval(0);
     while (it != eit)
     {
-      checkForInterruption(algo);
+
       mesh->get_nodes(nodearray, *it);
       size_t nsize = nodearray.size();
       DATA val(0);
@@ -110,7 +110,7 @@ MapFieldDataFromNodeToElemT(const MapFieldDataFromNodeToElemAlgo* algo,
   {
     while (it != eit)
     {
-      checkForInterruption(algo);
+
       mesh->get_nodes(nodearray, *it);
       size_t nsize = nodearray.size();
       DATA val(0);
@@ -139,7 +139,7 @@ MapFieldDataFromNodeToElemT(const MapFieldDataFromNodeToElemAlgo* algo,
     DATA tval(0);
     while (it != eit)
     {
-      checkForInterruption(algo);
+
       mesh->get_nodes(nodearray, *it);
       size_t nsize = nodearray.size();
       DATA val(0);
@@ -167,7 +167,7 @@ MapFieldDataFromNodeToElemT(const MapFieldDataFromNodeToElemAlgo* algo,
     DATA tval(0);
     while (it != eit)
     {
-      checkForInterruption(algo);
+
       mesh->get_nodes(nodearray, *it);
       size_t nsize = nodearray.size();
       DATA val(0);
@@ -191,7 +191,7 @@ MapFieldDataFromNodeToElemT(const MapFieldDataFromNodeToElemAlgo* algo,
     std::vector<DATA> valarray;
     while (it != eit)
     {
-      checkForInterruption(algo);
+
       mesh->get_nodes(nodearray, *it);
       size_t nsize = nodearray.size();
       valarray.resize(nsize);

--- a/src/Core/Algorithms/Legacy/Fields/Mapping/MapFieldDataFromSourceToDestination.cc
+++ b/src/Core/Algorithms/Legacy/Fields/Mapping/MapFieldDataFromSourceToDestination.cc
@@ -122,7 +122,6 @@ MapFieldDataFromSourceToDestinationClosestDataPAlgo::parallel(int proc)
 
     for (VMesh::Elem::index_type idx=start; idx<end;idx++)
     {
-      checkForInterruption();
       dmesh_->get_center(p,idx);
       double dist;
       if(smesh_->find_closest_elem(dist,r,didx,p))
@@ -141,7 +140,6 @@ MapFieldDataFromSourceToDestinationClosestDataPAlgo::parallel(int proc)
     VMesh::Elem::index_type didx;
     for (VMesh::Node::index_type idx=start; idx<end;idx++)
     {
-      checkForInterruption();
       dmesh_->get_center(p,idx);
       double dist;
       if(smesh_->find_closest_elem(dist,r,didx,p))
@@ -160,7 +158,6 @@ MapFieldDataFromSourceToDestinationClosestDataPAlgo::parallel(int proc)
     VMesh::Node::index_type didx;
     for (VMesh::Elem::index_type idx=start; idx<end;idx++)
     {
-      checkForInterruption();
       dmesh_->get_center(p,idx);
       double dist;
       if(smesh_->find_closest_node(dist,r,didx,p))
@@ -179,7 +176,6 @@ MapFieldDataFromSourceToDestinationClosestDataPAlgo::parallel(int proc)
     VMesh::Node::index_type didx;
     for (VMesh::Node::index_type idx=start; idx<end;idx++)
     {
-      checkForInterruption();
       dmesh_->get_center(p,idx);
       double dist;
       if(smesh_->find_closest_node(dist,r,didx,p))
@@ -239,7 +235,6 @@ MapFieldDataFromSourceToDestinationSingleDestinationPAlgo::parallel(int proc)
     VMesh::Elem::index_type didx;
     for (VMesh::Elem::index_type idx=start; idx<end;idx++)
     {
-      checkForInterruption();
       smesh_->get_center(p,idx);
       double dist;
       if(dmesh_->find_closest_elem(dist,r,coords,didx,p))
@@ -260,7 +255,6 @@ MapFieldDataFromSourceToDestinationSingleDestinationPAlgo::parallel(int proc)
     VMesh::Elem::index_type didx;
     for (VMesh::Node::index_type idx=start; idx<end;idx++)
     {
-      checkForInterruption();
       smesh_->get_center(p,idx);
       double dist;
       if(dmesh_->find_closest_elem(dist,r,coords,didx,p))
@@ -280,7 +274,6 @@ MapFieldDataFromSourceToDestinationSingleDestinationPAlgo::parallel(int proc)
     VMesh::Node::index_type didx;
     for (VMesh::Elem::index_type idx=start; idx<end;idx++)
     {
-      checkForInterruption();
       smesh_->get_center(p,idx);
       double dist;
       if(dmesh_->find_closest_node(dist,r,didx,p))
@@ -300,7 +293,6 @@ MapFieldDataFromSourceToDestinationSingleDestinationPAlgo::parallel(int proc)
     VMesh::Node::index_type didx;
     for (VMesh::Node::index_type idx=start; idx<end;idx++)
     {
-      checkForInterruption();
       smesh_->get_center(p,idx);
       double dist;
       if(dmesh_->find_closest_node(dist,r,didx,p))
@@ -371,7 +363,6 @@ MapFieldDataFromSourceToDestinationInterpolatedDataPAlgo::parallel(int proc)
 
     for (VMesh::Elem::index_type idx=start; idx<end;idx++)
     {
-      checkForInterruption();
       dmesh_->get_center(p,idx);
 
       double dist;
@@ -391,7 +382,6 @@ MapFieldDataFromSourceToDestinationInterpolatedDataPAlgo::parallel(int proc)
     VMesh::Elem::index_type didx;
     for (VMesh::Node::index_type idx=start; idx<end;idx++)
     {
-      checkForInterruption();
       dmesh_->get_center(p,idx);
       double dist;
       if(smesh_->find_closest_elem(dist,r,didx,p))
@@ -412,7 +402,6 @@ MapFieldDataFromSourceToDestinationInterpolatedDataPAlgo::parallel(int proc)
     VMesh::ElemInterpolate interp;
     for (VMesh::Elem::index_type idx=start; idx<end;idx++)
     {
-      checkForInterruption();
       dmesh_->get_center(p,idx);
       double dist;
       if(smesh_->find_closest_elem(dist,r,coords,didx,p))
@@ -435,7 +424,6 @@ MapFieldDataFromSourceToDestinationInterpolatedDataPAlgo::parallel(int proc)
     VMesh::ElemInterpolate interp;
     for (VMesh::Node::index_type idx=start; idx<end;idx++)
     {
-      checkForInterruption();
       dmesh_->get_center(p,idx);
       double dist;
       if(smesh_->find_closest_elem(dist,r,coords,didx,p))

--- a/src/Core/Algorithms/Legacy/Fields/Mapping/MapFieldDataOntoElems.cc
+++ b/src/Core/Algorithms/Legacy/Fields/Mapping/MapFieldDataOntoElems.cc
@@ -217,7 +217,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
       {
         for (VMesh::Elem::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           omesh->minterpolate(points,coords,idx);
           omesh->get_normals(norms,coords,idx);
           datasource->get_data(grads,points);
@@ -233,7 +233,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
       {
         for (VMesh::Elem::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           omesh->minterpolate(points,coords,idx);
           vol = omesh->get_size(idx);
           omesh->get_normals(norms,coords,idx);
@@ -250,7 +250,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
       {
         for (VMesh::Elem::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           omesh->minterpolate(points,coords,idx);
           omesh->get_normals(norms,coords,idx);
           datasource->get_data(grads,points);
@@ -266,7 +266,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
       {
         for (VMesh::Elem::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           omesh->minterpolate(points,coords,idx);
           omesh->get_normals(norms,coords,idx);
           datasource->get_data(grads,points);
@@ -282,7 +282,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
       {
         for (VMesh::Elem::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           omesh->minterpolate(points,coords,idx);
           omesh->get_normals(norms,coords,idx);
           datasource->get_data(grads,points);
@@ -299,7 +299,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         std::vector<double> common;
         for (VMesh::Elem::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           omesh->minterpolate(points,coords,idx);
           omesh->get_normals(norms,coords,idx);
           datasource->get_data(grads,points);
@@ -333,7 +333,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         std::vector<double> median;
         for (VMesh::Elem::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           omesh->minterpolate(points,coords,idx);
           omesh->get_normals(norms,coords,idx);
           datasource->get_data(grads,points);
@@ -374,7 +374,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             val = 0.0; size_t num = 0;
@@ -388,7 +388,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             vol = omesh->get_size(idx);
             datasource->get_data(values,points);
@@ -403,7 +403,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             val = std::numeric_limits<double>::max();
@@ -417,7 +417,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             val = -std::numeric_limits<double>::max();
@@ -431,7 +431,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             val = 0.0; size_t num = 0;
@@ -446,7 +446,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
           std::vector<double> common;
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             common.clear();
@@ -478,7 +478,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
           std::vector<double> median;
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             median.clear();
@@ -514,7 +514,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             val = Vector(0,0,0); size_t num = 0;
@@ -528,7 +528,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             vol = omesh->get_size(idx);
             datasource->get_data(values,points);
@@ -543,7 +543,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             val = Vector(0,0,0);
@@ -568,7 +568,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             val = Tensor(0); size_t num = 0;
@@ -582,7 +582,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             vol = omesh->get_size(idx);
             datasource->get_data(values,points);
@@ -597,7 +597,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             val = Tensor(0);
@@ -631,7 +631,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
       {
         for (VMesh::Elem::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           omesh->minterpolate(points,coords,idx);
           omesh->get_normals(norms,coords,idx);
           datasource->get_data(grads,points);
@@ -647,7 +647,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
       {
         for (VMesh::Elem::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           omesh->minterpolate(points,coords,idx);
           vol = omesh->get_size(idx);
           omesh->get_normals(norms,coords,idx);
@@ -664,7 +664,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
       {
         for (VMesh::Elem::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           omesh->minterpolate(points,coords,idx);
           omesh->get_normals(norms,coords,idx);
           datasource->get_data(grads,points);
@@ -679,7 +679,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
       {
         for (VMesh::Elem::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           omesh->minterpolate(points,coords,idx);
           omesh->get_normals(norms,coords,idx);
           datasource->get_data(grads,points);
@@ -694,7 +694,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
       {
         for (VMesh::Elem::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           omesh->minterpolate(points,coords,idx);
           omesh->get_normals(norms,coords,idx);
           datasource->get_data(grads,points);
@@ -709,7 +709,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
       {
         for (VMesh::Elem::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           omesh->minterpolate(points,coords,idx);
           omesh->get_normals(norms,coords,idx);
           datasource->get_data(grads,points);
@@ -734,7 +734,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
       {
         for (VMesh::Elem::index_type idx=start; idx<end; idx++)
         {
-          checkForInterruption();
+
           omesh->minterpolate(points,coords,idx);
           omesh->get_normals(norms,coords,idx);
           datasource->get_data(grads,points);
@@ -767,7 +767,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             val = values[0];
@@ -781,7 +781,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             vol = omesh->get_size(idx);
             datasource->get_data(values,points);
@@ -796,7 +796,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             val = values[0];
@@ -809,7 +809,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             val = values[0];
@@ -822,7 +822,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             val = values[0];
@@ -835,7 +835,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             std::sort(values.begin(),values.end());
@@ -858,7 +858,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             std::sort(values.begin(),values.end());
@@ -886,7 +886,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             val = values[0];
@@ -900,7 +900,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             vol = omesh->get_size(idx);
             datasource->get_data(values,points);
@@ -915,7 +915,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             val = values[0];
@@ -941,7 +941,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             val = values[0];
@@ -955,7 +955,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             vol = omesh->get_size(idx);
             datasource->get_data(values,points);
@@ -970,7 +970,7 @@ MapFieldDataOntoElemsPAlgo::parallel(int proc)
         {
           for (VMesh::Elem::index_type idx=start; idx<end; idx++)
           {
-            checkForInterruption();
+
             omesh->minterpolate(points,coords,idx);
             datasource->get_data(values,points);
             val = values[0];

--- a/src/Core/Algorithms/Legacy/Fields/Mapping/MapFieldDataOntoNodes.cc
+++ b/src/Core/Algorithms/Legacy/Fields/Mapping/MapFieldDataOntoNodes.cc
@@ -123,7 +123,6 @@ MapFieldDataOntoNodesPAlgo::parallel(int proc)
     Point p; Vector val; Vector norm;
     for (VMesh::Node::index_type idx=start; idx<end; idx++)
     {
-      checkForInterruption();
       omesh->get_center(p,idx);
       omesh->get_normal(norm,idx);
       datasource->get_data(val,p);
@@ -139,7 +138,6 @@ MapFieldDataOntoNodesPAlgo::parallel(int proc)
       Point p; double val;
       for (VMesh::Node::index_type idx=start; idx<end; idx++)
       {
-        checkForInterruption();
         omesh->get_center(p,idx);
         datasource->get_data(val,p);
         ofield->set_value(val,idx);
@@ -151,7 +149,6 @@ MapFieldDataOntoNodesPAlgo::parallel(int proc)
       Point p; Vector val;
       for (VMesh::Node::index_type idx=start; idx<end; idx++)
       {
-        checkForInterruption();
         omesh->get_center(p,idx);
         datasource->get_data(val,p);
         ofield->set_value(val,idx);
@@ -163,7 +160,6 @@ MapFieldDataOntoNodesPAlgo::parallel(int proc)
       Point p; Tensor val;
       for (VMesh::Node::index_type idx=start; idx<end; idx++)
       {
-        checkForInterruption();
         omesh->get_center(p,idx);
         datasource->get_data(val,p);
         ofield->set_value(val,idx);
@@ -381,7 +377,7 @@ MapFieldDataOntoNodesAlgo::runImpl(FieldHandle source, FieldHandle destination, 
       return (false);
     }
   }
-  
+
   if (fi.is_pointcloud() && (mappingModel == "interpolateddata" || mappingModel == "closestinterpolateddata"))
   {
     warning("Point cloud source data will produce the same mapping as a closestnodedata mapping since the data lacks a basis for interpolation. See https://github.com/SCIInstitute/SCIRun/issues/2155");

--- a/src/Core/Algorithms/Legacy/Fields/MeshDerivatives/GetFieldBoundaryAlgo.cc
+++ b/src/Core/Algorithms/Legacy/Fields/MeshDerivatives/GetFieldBoundaryAlgo.cc
@@ -145,7 +145,7 @@ GetFieldBoundaryAlgo::run(FieldHandle input, FieldHandle& output, MatrixHandle& 
 
   while (be != ee)
   {
-    checkForInterruption(this);
+
     ci = *be;
     imesh->get_delems(delems, ci);
     for (size_t p = 0; p < delems.size(); p++)
@@ -267,7 +267,7 @@ GetFieldBoundaryAlgo::run(FieldHandle input, FieldHandle& output, MatrixHandle& 
 
     while (it != it_end)
     {
-      checkForInterruption(this);
+
       VMesh::Elem::index_type idx1((*it).second);
       VMesh::Elem::index_type idx2((*it).first);
 
@@ -284,7 +284,7 @@ GetFieldBoundaryAlgo::run(FieldHandle input, FieldHandle& output, MatrixHandle& 
 
     while (it != it_end)
     {
-      checkForInterruption(this);
+
       VMesh::Node::index_type idx1((*it).first);
       VMesh::Node::index_type idx2((*it).second);
       ofield->copy_value(ifield,idx1,idx2);
@@ -388,7 +388,7 @@ GetFieldBoundaryAlgo::run(FieldHandle input, FieldHandle& output) const
 
   while (be != ee)
   {
-    checkForInterruption(this);
+
     ci = *be;
     imesh->get_delems(delems, ci);
     for (size_t p = 0; p < delems.size(); p++)

--- a/src/Core/Algorithms/Legacy/Fields/StreamLines/GenerateStreamLines.cc
+++ b/src/Core/Algorithms/Legacy/Fields/StreamLines/GenerateStreamLines.cc
@@ -260,7 +260,7 @@ namespace detail
       // Try to find the streamline for each seed point.
       for (VMesh::Node::index_type idx = from; idx < to; ++idx)
       {
-        checkForInterruption();
+        
         seed_mesh_->get_point(BI.seed_, idx);
 
         // Is the seed point inside the field?

--- a/src/Core/Thread/Interruptible.h
+++ b/src/Core/Thread/Interruptible.h
@@ -60,8 +60,6 @@ namespace Core
 
     using Interruptible = Stoppable;
 
-    SCISHARE void checkForInterruption(const Stoppable* stoppable = nullptr);
-
     struct SCISHARE ThreadStopped : virtual ExceptionBase
     {};
   }

--- a/src/Core/Thread/Mutex.cc
+++ b/src/Core/Thread/Mutex.cc
@@ -90,11 +90,3 @@ void Stoppable::sendStopRequest()
   //std::cout << std::this_thread::get_id() << " " << __FUNCTION__ << std::endl;
   exitSignal->set_value();
 }
-
-void SCIRun::Core::Thread::checkForInterruption(const Stoppable* stoppable)
-{
-  if (stoppable && stoppable->stopRequested())
-  {
-    throw ThreadStopped();
-  }
-}

--- a/src/Modules/DataIO/WriteG3D.cc
+++ b/src/Modules/DataIO/WriteG3D.cc
@@ -161,8 +161,6 @@ void WriteG3D::calculateColors()
 
     while (eiter != eiter_end)
     {
-      checkForInterruption(this);
-
       Point p;
       mesh->get_point(p, *eiter);
 

--- a/src/Modules/Visualization/ShowField.cc
+++ b/src/Modules/Visualization/ShowField.cc
@@ -598,9 +598,6 @@ void GeometryBuilder::renderFacesLinear(
 
     while (facesLeftInThisPass > 0)
     {
-      if (stoppable_->stopRequested())
-        throw "stopped";
-
       mesh->get_nodes(nodes, *fiter);
 
       for(size_t i = 0; i < numNodesPerFace; ++i)
@@ -877,9 +874,6 @@ void GeometryBuilder::renderNodes(
   GlyphGeom glyphs;
   while (eiter != eiter_end)
   {
-    if (stoppable_->stopRequested())
-      throw "stopped";
-
     Point p;
     mesh->get_point(p, *eiter);
     //coloring options
@@ -974,9 +968,6 @@ void GeometryBuilder::renderEdges(
   GlyphGeom glyphs;
   while (eiter != eiter_end)
   {
-    if (stoppable_->stopRequested())
-      throw "stopped";
-
     VMesh::Node::array_type nodes;
     mesh->get_nodes(nodes, *eiter);
 

--- a/src/Modules/Visualization/ShowFieldGlyphs.cc
+++ b/src/Modules/Visualization/ShowFieldGlyphs.cc
@@ -551,7 +551,6 @@ void GlyphBuilder::renderVectors(
   // Render every item from facade
   for(int i = 0; i < indices.size(); i++)
   {
-    checkForInterruption(interruptible);
     Vector v, pinputVector; Point p2, p3; double radius;
 
     pinputVector = portHandler_->getPrimaryVector(indices[i]);
@@ -636,7 +635,6 @@ void GlyphBuilder::renderScalars(
   // Render every item from facade
   for(int i = 0; i < indices.size(); i++)
   {
-    checkForInterruption(interruptible);
 
     double v = portHandler_->getPrimaryScalar(indices[i]);
     ColorRGB node_color = portHandler_->getNodeColor(indices[i]);
@@ -732,8 +730,6 @@ void GlyphBuilder::renderTensors(
   // Render every item from facade
   for(int i = 0; i < indices.size(); i++)
   {
-    checkForInterruption(interruptible);
-
     Tensor t = portHandler_->getPrimaryTensor(indices[i]);
 
     double eigen1, eigen2, eigen3;


### PR DESCRIPTION
This didn't show up on Mac, so I missed it initially. It caused a crazy 300-1000X slow down in ShowField and any algorithm that (over)used the interruption feature using the new future/promise mechanism implemented in #2195, on Windows and Linux. That feature wasn't enabled in the GUI anyway, so I just took out all the checkForInterruption calls until I can figure out a less intrusive way to implement this. Please test and merge ASAP.

For example: ShowField on a 100^3 latvol went from 308 seconds to 1.42 seconds on my i7-10710U.