### PR TITLE
Fix Camera Rotation State Variable

### DIFF
--- a/src/Interface/Modules/Render/ViewScene.cc
+++ b/src/Interface/Modules/Render/ViewScene.cc
@@ -881,7 +881,7 @@ void ViewSceneDialog::pushCameraRotation()
   if(!spire) return;
 
   auto q = spire->getCameraRotation();
-  state_->setValue(Modules::Render::ViewScene::CameraRotation, makeAnonymousVariableList(q[0], q[1], q[2], q[3]));
+  state_->setValue(Modules::Render::ViewScene::CameraRotation, makeAnonymousVariableList(q.w, q.x, q.y, q.z));
   pushingCameraState_ = false;
 }
 


### PR DESCRIPTION
Fixes #2254

I changed the array accesses of glm::quat to the wxyz variables for camera state. This is needed because the data ordering is no longer consistent with the constructor ordering with the recent glm upgrade.

Here are python commands for getting and setting the camera state for testing:
rot = scirun_get_module_state('ViewScene:0','CameraRotation')
scirun_set_module_state('ViewScene:0','CameraRotation', rot)

Reviewers: @dcwhite @jessdtate 
@jab0707 you're welcome to test if you'd like