### PR TITLE
OSPRay Upgrade to 2.10

### DIFF
--- a/Superbuild/OsprayExternal.cmake
+++ b/Superbuild/OsprayExternal.cmake
@@ -25,7 +25,8 @@
 #  DEALINGS IN THE SOFTWARE.
 
 SET_PROPERTY(DIRECTORY PROPERTY "EP_BASE" ${ep_base})
-SET(ospray_GIT_TAG "origin/scirun-build-2.4")
+# SET(ospray_GIT_TAG "origin/scirun-build-2.4")
+SET(ospray_GIT_TAG "origin/cibc-2.10")
 
 set(ospray_DEPENDENCIES)
 LIST(APPEND ospray_DEPENDENCIES GLM_external)
@@ -34,7 +35,8 @@ LIST(APPEND ospray_DEPENDENCIES GLM_external)
 # git checkout -q will silence message about detached head (harmless).
 ExternalProject_Add(Ospray_external
   DEPENDS ${ospray_DEPENDENCIES}
-  GIT_REPOSITORY "https://github.com/CIBC-Internal/ospray.git"
+  # GIT_REPOSITORY "https://github.com/CIBC-Internal/ospray.git"
+  GIT_REPOSITORY "https://github.com/tarkpate/ospray.git"
   GIT_TAG ${ospray_GIT_TAG}
   PATCH_COMMAND ""
   INSTALL_DIR ""

--- a/Superbuild/OsprayExternal.cmake
+++ b/Superbuild/OsprayExternal.cmake
@@ -25,7 +25,6 @@
 #  DEALINGS IN THE SOFTWARE.
 
 SET_PROPERTY(DIRECTORY PROPERTY "EP_BASE" ${ep_base})
-# SET(ospray_GIT_TAG "origin/scirun-build-2.4")
 SET(ospray_GIT_TAG "origin/cibc-2.10")
 
 set(ospray_DEPENDENCIES)

--- a/src/Core/Thread/Mutex.h
+++ b/src/Core/Thread/Mutex.h
@@ -32,6 +32,7 @@
 #include <boost/noncopyable.hpp>
 #include <thread>
 #include <mutex>
+#include <string>
 #include <Core/Thread/share.h>
 
 namespace SCIRun


### PR DESCRIPTION
Links to git tag from the [PR](https://github.com/CIBC-Internal/ospray/pull/7) branch for testing purposes. After that PR is merged, I'll revert the git repo back to cibc-internal.

Also, I added a include string statement in Mutex. I was getting errors on both of my machines that it was missing when I tried to build with OSPRay.