### PR TITLE
Only initialize the CLI for headless mode and add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.github
+scripts
+.clang-format
+.git 
+.gitattributes
+.gitignore
+.travis.yml
+build.sh
+compile_commands.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+#syntax=docker/dockerfile:1-labs
+FROM ubuntu:24.04
+
+ARG SCIRUN_VERSION="v5.0-beta.2023"
+
+RUN apt-get -y update \
+    && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install qtbase5-dev libqt5svg5-dev \
+    cmake git openssl tzdata build-essential g++ zlib1g-dev libssl-dev libncurses-dev libsqlite3-dev \
+    libreadline-dev libtk-img-dev libgdm-dev libdb-dev libpcap-dev \
+    && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
+
+WORKDIR /scirun-src
+COPY . /scirun-src/
+# RUN git clone --depth 1 --branch ${SCIRUN_VERSION} https://github.com/georgiastuart/SCIRun.git .
+
+WORKDIR /opt/scirun
+# TODO: Separate external building from SCIRun
+RUN cmake -DQt_PATH=/usr/lib/x86_64-linux-gnu/cmake \
+    -DCMAKE_BUILD_TYPE=Release /scirun-src/Superbuild && make
+
+# Make the internal python usable externally
+ENV LD_LIBRARY_PATH=/opt/scirun/Externals/Install/Python_external/lib:$LD_LIBRARY_PATH
+ENV PATH=/opt/scirun/SCIRun:/opt/scirun/Externals/Install/Python_external/bin:$PATH 
+RUN python3 -m ensurepip && python3 -m pip install --upgrade pip && python3 -m venv /opt/venv
+
+WORKDIR /opt/scripts 
+COPY <<EOF /opt/scripts/entrypoint.sh
+set -e 
+. /opt/venv/bin/activate
+exec "\$@"
+EOF
+
+RUN chmod a+x /opt/scripts/entrypoint.sh
+
+WORKDIR /data
+ENTRYPOINT [ "/opt/scripts/entrypoint.sh" ]
+CMD ["/opt/scirun/SCIRun/SCIRun"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get -y update \
 
 WORKDIR /scirun-src
 COPY . /scirun-src/
-# RUN git clone --depth 1 --branch ${SCIRUN_VERSION} https://github.com/georgiastuart/SCIRun.git .
 
 WORKDIR /opt/scirun
 # TODO: Separate external building from SCIRun

--- a/src/Main/scirunMain.cc
+++ b/src/Main/scirunMain.cc
@@ -65,7 +65,11 @@ int mainImpl(int argc, const char* argv[], char **environment)
   //TODO: must read --headless flag here, or try pushing command queue building all the way up here
   //TODO: https://doc.qt.io/qt-5/qapplication.html#details
 #ifndef BUILD_HEADLESS
-  return GuiApplication::run(argc, argv);
+  if (!Application::Instance().parameters()->disableGui()) {
+    return GuiApplication::run(argc, argv);
+  } else {
+    return ConsoleApplication::run(argc, argv);
+  }
 #else
   return ConsoleApplication::run(argc, argv);
 #endif

--- a/src/Main/scirunMain.cc
+++ b/src/Main/scirunMain.cc
@@ -65,7 +65,7 @@ int mainImpl(int argc, const char* argv[], char **environment)
   //TODO: must read --headless flag here, or try pushing command queue building all the way up here
   //TODO: https://doc.qt.io/qt-5/qapplication.html#details
 #ifndef BUILD_HEADLESS
-  if (!Application::Instance().parameters()->disableGui()) {
+  if (!Application::Instance().parameters()->disableGui() && !Application::Instance().parameters()->help()) {
     return GuiApplication::run(argc, argv);
   } else {
     return ConsoleApplication::run(argc, argv);


### PR DESCRIPTION
I've been helping a group use SCIRun on our local cluster. As part of that work, I made a couple changes to SCIRun that may be useful to others. Namely...

1. Containerization was easier than keeping SCIRun happy with Cluster QT offerings, particularly after a cluster-wide OS update. I created a Dockerfile, which should be broadly useful.
2. SCIRun refused to start within SLURM batch jobs or CLI interactive jobs and would only run if it was either (a) compiled completely headless or (b) run within our GUI desktop, even when `-x` was specified, since QT always tried to identify a display. To solve this, I added a check for `-x` or `-h` to the Main function to initialize the command line program instead. 

Seems to work fine locally. Tested on an Ubuntu 24.04 system using the Apptainer runtime from a docker image. 