### PR TITLE
Fix regression CI: pin windows runner to windows-2022

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -34,7 +34,7 @@ jobs:
   windows-headless-regression:
     uses: ./.github/workflows/reusable-build.yml
     with:
-      runner: windows-latest
+      runner: windows-2022
       variant: headless
       build-testing: true
       run-unit-tests: true


### PR DESCRIPTION
`windows-latest` now maps to a runner image where CMake cannot find Visual Studio 17 2022, causing an immediate configure failure in `windows-headless-regression`. Every other Windows CI job already pins to `windows-2022` explicitly — this aligns the regression job to match.

One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)