### PR TITLE
Fix PS5.1 compatibility and add path-length warning in build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -74,6 +74,16 @@
     Directory for build files. Relative paths are resolved from the repo root.
     Default: <repo root>\bin
 
+    IMPORTANT -- Windows path length: The SCIRun Superbuild generates deeply
+    nested paths inside the build directory. If the total path to a generated
+    file exceeds Windows' 260-character MAX_PATH limit, the MSVC compiler will
+    fail with a cryptic "filename too long" or C1083 error. To avoid this,
+    choose a short path near the root of a drive, such as C:\SR or D:\build,
+    rather than the default location inside the repository tree (which may
+    already be 40-60 characters deep).
+
+    Example: -BuildDir "C:\SR"
+
 .PARAMETER Jobs
     Number of parallel compile jobs. Default: number of logical CPU cores.
     Lower this (e.g. -Jobs 4) if the build runs out of memory.
@@ -104,8 +114,9 @@
     Debug build limited to 4 parallel jobs (useful on low-memory machines).
 
 .EXAMPLE
-    .\build.ps1 -QtPath "C:\Qt\5.15.2\msvc2019_64" -BuildDir "C:\SCIRunBuild"
-    Release build with explicit Qt path and a custom build directory.
+    .\build.ps1 -QtPath "C:\Qt\5.15.2\msvc2019_64" -BuildDir "C:\SR"
+    Release build with explicit Qt path and a short build directory (recommended
+    on Windows to avoid MAX_PATH filename-too-long errors).
 
 .EXAMPLE
     .\build.ps1 -Qt6
@@ -710,6 +721,15 @@ if ($BuildDir -ne "") {
     $resolvedBuildDir = Join-Path $sourceDir "bin"
 }
 
+if ($resolvedBuildDir.Length -gt 50) {
+    Write-Warn "Build directory path is $($resolvedBuildDir.Length) characters long:"
+    Write-Warn "  $resolvedBuildDir"
+    Write-Warn "The SCIRun Superbuild generates deeply nested paths. Paths longer than"
+    Write-Warn "~260 characters cause MSVC 'filename too long' (C1083) errors on Windows."
+    Write-Warn "Consider a shorter path, e.g.: -BuildDir C:\SR"
+    Write-Host ""
+}
+
 if ($Debug -and $Release) {
     Exit-WithError "Cannot specify both -Debug and -Release. Omit both for the default Release build."
 }
@@ -736,7 +756,8 @@ if ($Qt6) {
 $numJobs = if ($Jobs -gt 0) {
     $Jobs
 } else {
-    [int]([Environment]::GetEnvironmentVariable("NUMBER_OF_PROCESSORS") ?? "4")
+    $env_procs = [Environment]::GetEnvironmentVariable("NUMBER_OF_PROCESSORS")
+    if ($env_procs) { [int]$env_procs } else { 4 }
 }
 
 # Print summary


### PR DESCRIPTION
## Summary

- Replace the PowerShell 7-only `??` null-coalescing operator (line 739) with a PS 5.1-compatible `if`/`else` block — fixes a parse error on Windows' default PowerShell version reported in [#2512](https://github.com/SCIInstitute/SCIRun/discussions/2512)
- Add a runtime warning when the resolved build directory path exceeds 50 characters, alerting users before they hit Windows' 260-character MAX_PATH limit deep in the Superbuild tree
- Expand `-BuildDir` parameter documentation with an `IMPORTANT` note on the MAX_PATH limit, recommended short paths (`C:\SR`, `D:\build`), and update the example accordingly

## Test plan

- [ ] Run `build.ps1` on Windows PowerShell 5.1 (the default) — should no longer error on `??`
- [ ] Run with a long default path (repo checked out deep in `C:\Users\...`) and confirm the path-length warning fires
- [ ] Run with `-BuildDir "C:\SR"` and confirm no warning and clean configure/build
- [ ] `Get-Help .\build.ps1 -Full` shows the updated `-BuildDir` documentation

Closes the issue reported in https://github.com/SCIInstitute/SCIRun/discussions/2512

🤖 Generated with [Claude Code](https://claude.com/claude-code)