### PR TITLE
Fix --version segfault on exit on macOS (Qt 6.10.x DeferredDelete during __cxa_finalize)

### DIFF
--- a/src/Main/scirunMain.cc
+++ b/src/Main/scirunMain.cc
@@ -65,7 +65,9 @@ int mainImpl(int argc, const char* argv[], char **environment)
   //TODO: must read --headless flag here, or try pushing command queue building all the way up here
   //TODO: https://doc.qt.io/qt-5/qapplication.html#details
 #ifndef BUILD_HEADLESS
-  if (Application::Instance().parameters()->disableGui() || Application::Instance().parameters()->help()) 
+  if (Application::Instance().parameters()->disableGui()
+    || Application::Instance().parameters()->help()
+    || Application::Instance().parameters()->version())
   {
     return ConsoleApplication::run(argc, argv);
   }


### PR DESCRIPTION
Fixes #2560.

## Problem

On macOS with Qt 6.10.x, `SCIRun --version` (and `-v`) prints the version and then **segfaults during exit** (exit code 139).

`--version` fell through to the GUI path, which builds a `QApplication` + `SCIRunMainWindow`. `QuitCommandGui::execute()` then calls `SCIRunMainWindow::quit()` → `exitApplication(0)` → `close()`; because the window has `Qt::WA_DeleteOnClose`, `close()` posts a `DeferredDelete`. Control returns and libc `exit(0)` fires. **Newer Qt 6.x flushes posted events during `QCoreApplication`'s static teardown inside `__cxa_finalize`**, so the `DeferredDelete` runs `~SCIRunMainWindow()` → `Application::Instance().shutdown()` after the `Application` singleton has already been finalized → use-after-finalize → SIGSEGV. Qt 6.5.3 discarded that event and exited cleanly, so this surfaced purely as a Qt upgrade. Full analysis + a standalone ~40-line reproducer (no SCIRun) are in #2560.

## Fix

`--version` needs no GUI. Route it to the console path alongside `--help`, which never had this problem because it builds no Qt window (hence no deferred-delete to flush):

```cpp
  if (Application::Instance().parameters()->disableGui()
    || Application::Instance().parameters()->help()
    || Application::Instance().parameters()->version())   // <-- added
  {
    return ConsoleApplication::run(argc, argv);
  }
```

## Verification (macOS, Qt 6.10.2, via `SCIRun_test`)

| Command | Before | After |
|---|---|---|
| `--version` | 139 (SIGSEGV) | 0 |
| `-v` | 139 (SIGSEGV) | 0 |
| `--help` | 0 | 0 (unchanged) |

Normal GUI launch is untouched — the new condition only fires when `version()` is true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
