### PR TITLE
Fix Windows Python_external configure: use native path for build.bat

### DIFF
--- a/Superbuild/PythonExternal.cmake
+++ b/Superbuild/PythonExternal.cmake
@@ -110,7 +110,10 @@ ELSE()
     PATCH_COMMAND ""
     # aka.ms/nugetclidl (used by PCbuild/find_python.bat) can redirect to a Bing
     # search page instead of the NuGet installer; point straight at the real host.
-    CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env "NUGET_URL=https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" PCbuild/build.bat
+    # The batch file must use native separators: "cmake -E env" launches a .bat
+    # through cmd, which reads the "/" in "PCbuild/build.bat" as a switch and
+    # fails with "'PCbuild' is not recognized as an internal or external command".
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env "NUGET_URL=https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" "PCbuild\\build.bat"
     BUILD_IN_SOURCE ON
     BUILD_COMMAND ${CMAKE_BUILD_TOOL} PCbuild/pcbuild.sln /nologo /property:Configuration=Release /property:Platform=${python_WIN32_ARCH}
     INSTALL_COMMAND "${CMAKE_COMMAND}" -E


### PR DESCRIPTION
## Problem

Master's Windows superbuild is currently broken. `windows-build-script / windows-headless` fails in ~3 minutes:

```
Performing configure step for 'Python_external'
'PCbuild' is not recognized as an internal or external command,
operable program or batch file.
...
error MSB8066: Custom build for '...Python_external-configure.rule...' exited with code 1
```

## Cause

#2566 wrapped the configure step in `cmake -E env` to force `NUGET_URL`, but left the batch file path with a forward slash:

```cmake
CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env "NUGET_URL=..." PCbuild/build.bat
```

Previously the command was just `PCbuild/build.bat` and CMake ran it directly. Now that it goes through `cmake -E env`, the `.bat` is launched via `cmd`, which treats the `/` as a switch separator — so it tries to execute a command named `PCbuild` with a `/build.bat` flag.

## Fix

Use native separators: `"PCbuild\build.bat"`.

Verified locally, reproducing both sides:

| Command | Result |
|---|---|
| `cmake -E env NUGET_URL=... PCbuild/build.bat` | `'PCbuild' is not recognized...` (matches CI) |
| `cmake -E env NUGET_URL=... PCbuild\build.bat` | batch runs, `NUGET_URL` correctly set |

So #2566's actual purpose (pinning the NuGet URL away from the `aka.ms` redirect) is preserved.

Only `CONFIGURE_COMMAND` needs this. `BUILD_COMMAND` passes `PCbuild/pcbuild.sln` as an *argument* to `msbuild.exe` rather than as the command itself, so it is unaffected.

## Note

This is unrelated to the other Windows failure seen on the 2026-07-18 master push (`windows-build / windows-headless`), which fails in Python's SBOM regen step (`py -3.13 ... generate_sbom.py` exiting 1). That one is being looked at separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)