### PR TITLE
CI: split PR checks from the full matrix; fix docs-only PRs being unmergeable

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,12 +1,22 @@
 name: linux-build
 
+# Full linux matrix: master pushes, nightly, and on demand. Pull requests are
+# covered by the slim tier in pr.yml -- see the comment at the top of that file
+# for why no required check may live in a path-filtered workflow.
+
 on:
   push:
+    branches:
+      - master
     paths-ignore:
       - 'docs/**'
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   linux-gui:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,9 +1,22 @@
 name: mac-build
 
+# Full mac matrix: master pushes, nightly, and on demand. Pull requests are
+# covered by the slim tier in pr.yml -- see the comment at the top of that file
+# for why no required check may live in a path-filtered workflow.
+
 on:
-  pull_request:
+  push:
+    branches:
+      - master
     paths-ignore:
       - 'docs/**'
+  schedule:
+    - cron: '30 8 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,145 @@
+name: pr
+
+# Slim, always-triggered PR tier.
+#
+# Two rules keep this workflow both cheap and mergeable:
+#
+#  1. No `paths-ignore` on `on:`. A workflow suppressed by a path filter never
+#     reports its checks at all, so a *required* context stays Pending forever
+#     and the pull request can never merge. A job that runs and is skipped by an
+#     `if:` reports "skipped", which branch protection counts as passing. Path
+#     filtering therefore happens at the job level below, never at `on:`.
+#
+#  2. `ci-gate` is the only context that should be marked required in branch
+#     protection. It always runs, so it can always report, and it mirrors the
+#     result of the builds it depends on. Requiring the nested `<job> / build`
+#     contexts directly re-creates the problem in rule 1 as soon as one of them
+#     is filtered or renamed.
+#
+# The full matrix (all the mac-headless-*, windows-gui-python-*, regression and
+# coverage variants) lives in ccpp.yml / mac.yml / windows.yml /
+# regression-tests.yml / windows-build-script.yml and runs on master pushes and
+# nightly -- not on every pull request. Use the `workflow_dispatch` trigger on
+# those workflows to run the full matrix against a risky branch on demand.
+
+on:
+  pull_request:
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - name: Classify changed paths
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          files=$(gh pr view "${{ github.event.pull_request.number }}" \
+                    --repo "${{ github.repository }}" \
+                    --json files --jq '.files[].path')
+
+          echo "Changed files:"
+          echo "$files"
+
+          count=$(printf '%s\n' "$files" | grep -c . || true)
+
+          # Fail safe towards building: an empty list, or one long enough to have
+          # been truncated by the API, must not be mistaken for a docs-only PR.
+          if [ "$count" -eq 0 ] || [ "$count" -ge 100 ]; then
+            docs_only=false
+          elif printf '%s\n' "$files" | grep -qvE '^docs/'; then
+            docs_only=false
+          else
+            docs_only=true
+          fi
+
+          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+          echo "docs_only=$docs_only"
+
+  linux-gui:
+    needs: changes
+    if: needs.changes.outputs.docs_only == 'false'
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      runner: ubuntu-latest
+      qt-version: ''
+      variant: gui
+      build-with-python: true
+
+  mac-gui:
+    needs: changes
+    if: needs.changes.outputs.docs_only == 'false'
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      runner: macOS-latest
+      qt-version: '6.10.2'
+      scirun-qt-min-version: '6.3.1'
+      variant: gui
+      build-with-python: true
+      artifact-name: SCIRunMacInstaller
+
+  windows-gui-qt6:
+    needs: changes
+    if: needs.changes.outputs.docs_only == 'false'
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      runner: windows-2022
+      qt-version: '6.3.*'
+      variant: gui
+      build-with-python: false
+      artifact-name: SCIRunWindowsInstaller_qt6
+
+  # Unit tests. The ctest step in reusable-build.yml carries
+  # `continue-on-error: true`, so a failing test does NOT fail this job today --
+  # master currently has 4 failing unit suites plus a large body of failing
+  # .Test.ImportNetwork.* cases. What this job does gate on is the build: test
+  # code that no longer compiles will fail the job, and hence ci-gate. The test
+  # results themselves are visible in the log and the uploaded artifact.
+  #
+  # Once the outstanding failures are fixed, drop `continue-on-error` from the
+  # "Run unit tests" steps in reusable-build.yml and this becomes a real gate
+  # with no change needed here.
+  linux-unit-tests:
+    needs: changes
+    if: needs.changes.outputs.docs_only == 'false'
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      runner: ubuntu-latest
+      variant: headless
+      build-testing: true
+      run-unit-tests: true
+
+  # The single required check. `if: always()` is what lets it report even when
+  # every build above was skipped, which is the case that unblocks docs-only PRs.
+  ci-gate:
+    name: ci-gate
+    if: always()
+    needs: [changes, linux-gui, mac-gui, windows-gui-qt6, linux-unit-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report upstream results
+        run: |
+          echo "changes:          ${{ needs.changes.result }}"
+          echo "linux-gui:        ${{ needs.linux-gui.result }}"
+          echo "mac-gui:          ${{ needs.mac-gui.result }}"
+          echo "windows-gui-qt6:  ${{ needs.windows-gui-qt6.result }}"
+          echo "linux-unit-tests: ${{ needs.linux-unit-tests.result }}"
+
+      - name: Fail if any required build failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "::error::One or more required builds did not succeed."
+          exit 1
+
+      - name: Pass
+        run: echo "All required builds succeeded or were skipped."

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,13 +1,21 @@
 name: regression-tests
 
+# Regression and coverage matrix: master pushes, nightly, and on demand. Pull
+# requests are covered by the slim tier in pr.yml -- see the comment at the top
+# of that file for why no required check may live in a path-filtered workflow.
+
 on:
   push:
     branches:
       - regression-tests-ci
       - master
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
+  schedule:
+    - cron: '45 8 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   linux-headless-regression:

--- a/.github/workflows/windows-build-script.yml
+++ b/.github/workflows/windows-build-script.yml
@@ -1,12 +1,22 @@
 name: windows-build-script
 
+# Exercises build.ps1 end to end: master pushes, nightly, and on demand. Pull
+# requests are covered by the slim tier in pr.yml -- see the comment at the top
+# of that file for why no required check may live in a path-filtered workflow.
+
 on:
   push:
+    branches:
+      - master
     paths-ignore:
       - 'docs/**'
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
+  schedule:
+    - cron: '15 8 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   windows-headless:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,12 +1,22 @@
 name: windows-build
 
+# Full windows matrix: master pushes, nightly, and on demand. Pull requests are
+# covered by the slim tier in pr.yml -- see the comment at the top of that file
+# for why no required check may live in a path-filtered workflow.
+
 on:
   push:
+    branches:
+      - master
     paths-ignore:
       - 'docs/**'
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
+  schedule:
+    - cron: '15 8 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   windows-headless:


### PR DESCRIPTION
![Yo dawg I herd you like PRs, so I made a PR about PRs so you can PR while you PR](https://i.imgflip.com/ax8emr.jpg)

With that out of the way:

## The bug

Docs-only pull requests can never merge.

Every build workflow filtered itself out with `paths-ignore: docs/**` at the `on:`
level. A workflow suppressed by a path filter **never reports its checks at all**,
so the required `mac-gui / build` context sits Pending forever. This is the trap:

| | reports as | branch protection says |
|---|---|---|
| job runs, skipped by `if:` | `skipped` | ✅ passing |
| workflow never triggers | *nothing* | ⏳ Pending, blocked forever |

It looked intermittent because `ccpp.yml` and `windows.yml` also triggered on
`push`, where path filters evaluate the **pushed commits** rather than the PR
diff. Merging master into a docs branch pushes non-docs files and accidentally
rescues two of the three required checks. `mac.yml` had no `push` trigger, so
`mac-gui / build` never got rescued.

#2555 (one file under `docs/`, approved, green everywhere it ran) is stuck this
way right now.

## The fix

**New `pr.yml`** — an always-triggered slim tier. No `paths-ignore` on `on:`, so
it can always report. Path filtering moves to the job level, where "skipped"
counts as passing. It ends in a single `ci-gate` job running with `if: always()`,
which mirrors whether the builds passed, were skipped, or failed.

**Full matrix moved to the nightly tier** — `ccpp.yml`, `mac.yml`, `windows.yml`,
`windows-build-script.yml` and `regression-tests.yml` now run on master pushes, a
staggered nightly cron, and `workflow_dispatch` for on-demand runs against a risky
branch. Their `pull_request` triggers are gone.

This also stops every job in `ccpp.yml` and `windows.yml` running **twice** per
PR, which it did because both `push` and `pull_request` fired for same-repo
branches.

| | before | after |
|---|---|---|
| code PR | ~40 jobs | 6 (four builds + path detect + gate) |
| docs PR | ~40 jobs, unmergeable | 2 trivial jobs, mergeable |

That matters more than it looks: `master` has `strict: true`, so every merge
invalidates every other open PR and forces a re-run. Those re-runs are now 6 jobs
instead of 40.

## Unit tests now run on PRs

New `linux-unit-tests` job in the PR tier (headless, `BUILD_TESTING=ON`).

Note what it does and does not gate. The ctest steps in `reusable-build.yml` carry
`continue-on-error: true`, so **a failing test does not fail the job** — that
stays as-is until the outstanding failures are fixed. What this job *does* gate on
is compilation: test code that stops building fails the job, and hence `ci-gate`.
Test results are visible in the job log and the uploaded artifact.

When the failures are fixed, drop `continue-on-error` from the "Run unit tests"
steps in `reusable-build.yml` and this becomes a real gate with no change to
`pr.yml`.

## While wiring that up: the unit test numbers are misleading

The most recent green `linux-headless-regression` run on master reports
**`10% tests passed, 438 tests failed out of 488`** in its unit test step. It
reported success anyway, because of `continue-on-error`.

Those 438 break down exactly as:

| | count | what |
|---|---|---|
| `.Test.ImportNetwork.*` | 434 | legacy v4 network imports |
| real unit suites | 4 | see below |

The unit test invocation is `ctest -E "\.Test\.ExampleNetwork\."`, which excludes
the regression networks but **not** `.Test.ImportNetwork.*` — so 434 legacy import
failures are swept into the unit test run and bury the actual signal. The genuine
unit failures are only:

- `Unit.testSCIRunAddModule.TestSCIRunAddModule.test_scirun_module_ids`
- `Core_Serialization_Network_Tests`
- `Engine_Python_Tests` *(Subprocess aborted)*
- `Algorithms_Field_Tests`

That is 4 out of ~54 suites, and matches the known count with #2551's two fixes
already accounted for. Separately, the regression step reports 96% passed / 10
failed of 247.

Not fixed here — flagging it because "438 failed" reads like a catastrophe and is
mostly one mis-scoped filter.

## Merge order

The PR-tier jobs deliberately keep the names `linux-gui`, `mac-gui` and
`windows-gui-qt6`, so `pr.yml` emits the same three nested contexts that branch
protection requires today, plus `ci-gate`. **This PR satisfies the current rules
on its own — no settings change needed to land it.**

- [x] Merge this
- [x] Change required contexts from `linux-gui / build`, `mac-gui / build`,
      `windows-gui-qt6 / build` → just `ci-gate`
- [x] Open a throwaway PR touching one file under `docs/` and confirm `ci-gate`
      goes green with all builds skipped
- [x] Unstick #2555

## Verified vs. not

Checked locally: all 11 workflows parse; only `pr.yml` retains a `pull_request`
build trigger; the docs-only detection is correct across 8 cases including
`documentation/` correctly *not* matching `^docs/`, the empty-list and >100-file
fail-safes, and #2555's exact one-file input.

Not verified without a live run: that a skipped required job actually satisfies
branch protection. It's documented behavior, and this repo's own
`linux-gui-ospray` / `mac-gui-ospray` (`if: false`) already report SKIPPED — but
those aren't required checks, so that's corroborating rather than proof. Hence the
throwaway-docs-PR step above.

## Deliberately not included

Installer artifacts are kept on the PR tier's mac/windows jobs, matching current
behavior. Dropping them is easy further savings if nobody pulls them off PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
