### PR TITLE
CI: cache Superbuild externals between runs

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -74,6 +74,27 @@ jobs:
       - name: Print Qt dir
         run: echo "QT_ROOT_DIR=${QT_ROOT_DIR:-(unset)}"
 
+      # Superbuild externals change rarely but cost the bulk of every build.
+      # Cache the whole Externals tree: the inner SCIRun build consumes headers
+      # and libraries from Source/ (Eigen, GLM, SpdLog, Boost stage), Build/
+      # (Zlib, Teem, ...), and Install/ (Python, Tetgen, Qwt) alike. Exact-key
+      # match only -- a prefix-matched stale tree would be silently used with
+      # the wrong externals because the restored stamps defeat ExternalProject's
+      # own staleness detection (see touch_external_stamps in build.sh).
+      # Windows is scoped out for now: different build dir, per-config stamp
+      # layout under the VS generator.
+      - name: Restore Superbuild externals cache
+        id: cache-externals
+        if: ${{ runner.os != 'Windows' }}
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            bin/Externals
+            !bin/Externals/Download
+            !bin/Externals/Source/**/.git
+            !bin/Externals/Stamp/SCIRun_external
+          key: superbuild-v1-${{ inputs.runner }}-${{ inputs.variant }}-py${{ inputs.build-with-python }}-qt${{ inputs.qt-version }}-osp${{ inputs.with-ospray }}-cov${{ inputs.coverage }}-${{ hashFiles('Superbuild/**') }}
+
       - name: Checkout SCIRunTestData
         if: ${{ inputs.run-regression-tests || inputs.coverage }}
         uses: actions/checkout@v6
@@ -90,6 +111,8 @@ jobs:
       - name: Build (Linux/macOS)
         if: ${{ runner.os != 'Windows' }}
         shell: bash
+        env:
+          SCIRUN_TOUCH_EXTERNAL_STAMPS: ${{ steps.cache-externals.outputs.cache-hit == 'true' && '1' || '0' }}
         run: |
           set -eux
           CMD=(./build.sh)
@@ -206,6 +229,19 @@ jobs:
           & cmake --build . --config Release --parallel
 
           Pop-Location
+
+      # Save only after a successful build on a cache miss; a hit means this
+      # exact key is already stored (immutable), so saving again would fail.
+      - name: Save Superbuild externals cache
+        if: ${{ runner.os != 'Windows' && steps.cache-externals.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            bin/Externals
+            !bin/Externals/Download
+            !bin/Externals/Source/**/.git
+            !bin/Externals/Stamp/SCIRun_external
+          key: ${{ steps.cache-externals.outputs.cache-primary-key }}
 
       - name: Smoke test - executable loads and runs (Unix)
         if: ${{ inputs.run-smoke-test && runner.os != 'Windows' }}

--- a/Superbuild/Superbuild.cmake
+++ b/Superbuild/Superbuild.cmake
@@ -70,6 +70,13 @@ ENDIF()
 
 INCLUDE( ExternalProject )
 
+# Skip the per-external git fetch on reconfigure. Every external pins a tag or
+# tracking branch that changes rarely; the fetch mostly costs network time and,
+# on CI runs that restore the Externals tree from a cache (without .git dirs),
+# would fail outright. Each external keeps an explicit <name>_external-update
+# target for developers who want to pull updates deliberately.
+SET_PROPERTY(DIRECTORY PROPERTY EP_UPDATE_DISCONNECTED TRUE)
+
 ###########################################
 # DETERMINE ARCHITECTURE
 # In order for the code to depend on the architecture settings

--- a/build.sh
+++ b/build.sh
@@ -141,6 +141,21 @@ build_scirun() {
     build_scirun_make
 }
 
+# When CI restores Externals/ from a cache, the restored stamp files are older
+# than the runner's CMake modules and configure-time scripts, so make would
+# consider every ExternalProject step out of date and redo them all -- including
+# deleting and re-cloning sources. Future-dating the stamps keeps completed
+# external steps completed. SCIRun_external's stamps are excluded so SCIRun
+# itself always reconfigures and rebuilds. Gated on an env var CI sets only
+# when a cache was actually restored; local builds are unaffected.
+touch_external_stamps() {
+    local stampdir="$builddir/Externals/Stamp"
+    if [[ "${SCIRUN_TOUCH_EXTERNAL_STAMPS:-0}" == "1" && -d "$stampdir" ]]; then
+        echo "Future-dating restored ExternalProject stamps in $stampdir"
+        find "$stampdir" -type f ! -path "*SCIRun_external*" -exec touch -t 210001010000 {} +
+    fi
+}
+
 ##########################################################################
 # build.sh script execution starts here
 ##########################################################################
@@ -232,5 +247,7 @@ ensure make --version
 echo "Build Type: $buildtype"
 
 configure_scirun
+
+touch_external_stamps
 
 build_scirun


### PR DESCRIPTION
Fixes #2520.

The externals (Boost, CPython, Teem, …) change rarely but dominate the wall time of every CI build. This caches the `Externals` tree keyed on the exact build flavor plus `hashFiles('Superbuild/**')`, so a run whose externals are unchanged only compiles SCIRun itself.

## Why it needs more than an actions/cache step

`ExternalProject` re-runs any step whose stamp is older than its inputs, and a cache restore produces exactly that — the runner's CMake modules and freshly written `Externals/tmp` scripts are newer than every restored stamp, so make would redo all external steps, including *deleting and re-cloning* `Source/`. Two supporting changes make a restored tree stick:

- `build.sh` future-dates the restored external stamps between configure and make, gated on `SCIRUN_TOUCH_EXTERNAL_STAMPS`, which CI sets only on a cache hit. `SCIRun_external`'s stamps are excluded (and not cached), so SCIRun itself always reconfigures and rebuilds. Local builds are untouched.
- The Superbuild sets `EP_UPDATE_DISCONNECTED TRUE` so reconfigure doesn't run `git fetch` inside restored `Source/` trees, which are cached **without** `.git` to keep entries small (~1–2 GB compressed). Developers keep the `<name>_external-update` targets for deliberate updates.

## Design notes

- **Exact-key restore only, no `restore-keys`**: with future-dated stamps, a prefix-matched stale cache would be silently used with the wrong externals. A key change means a clean cold build.
- Key includes runner, variant, python/qt/ospray/coverage flavor, and the Superbuild hash. The `superbuild-v1` prefix is the manual bust knob — e.g. if a branch-tracking external (LodePng `origin/master`, Tny) moves upstream without any `Superbuild/` edit, bump it to `v2`.
- Save runs only after a successful build on a cache miss.
- **Windows is scoped out** for now (different `build/` dir, per-config stamps under the VS generator) — can follow up if this proves out.

## Verification

- Locally: superbuild configure passes with `EP_UPDATE_DISCONNECTED`; the stamp-touch was exercised against a real configured `Externals/Stamp` tree — all external stamps future-date to 2100, `SCIRun_external`'s stay untouched.
- On this PR: the first CI run is cold and should show the cache save; a follow-up push will demonstrate the warm path (restore + externals skipped). I'll post both timings here.

Note: overlaps the same `reusable-build.yml` region and Superbuild files as #2513's caching groundwork (`.github/superbuild-caching.md`) — this implements the actions/cache half described there; happy to rebase on #2513 if that's landing first.