### PR TITLE
Fix aarch64/Linux Boost arch misdetection; add arm64 CI coverage (#2583)

### DIFF
--- a/.github/workflows/boost-platform-suffix.yml
+++ b/.github/workflows/boost-platform-suffix.yml
@@ -1,0 +1,37 @@
+name: Boost platform-suffix detection
+
+# Fast, dependency-free regression check for the Boost architecture detection
+# in Superbuild/UseBoost.cmake. It only runs `cmake` (the assertion fires at
+# configure time), so it finishes in seconds and never builds Boost or SCIRun.
+
+on:
+  push:
+    branches: ['**']
+    paths:
+      - 'Superbuild/UseBoost.cmake'
+      - 'Superbuild/Tests/BoostPlatformSuffix/**'
+      - '.github/workflows/boost-platform-suffix.yml'
+  pull_request:
+    paths:
+      - 'Superbuild/UseBoost.cmake'
+      - 'Superbuild/Tests/BoostPlatformSuffix/**'
+      - '.github/workflows/boost-platform-suffix.yml'
+  workflow_dispatch:
+
+jobs:
+  platform-suffix:
+    name: PLATFORM_SUFFIX on ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure test (asserts PLATFORM_SUFFIX matches host arch)
+        run: |
+          cmake -S Superbuild/Tests/BoostPlatformSuffix -B build-suffix-check

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -48,3 +48,29 @@ jobs:
       runner: ubuntu-latest
       variant: gui
       with-ospray: true
+
+  # arm64 (aarch64) coverage. GitHub-hosted Linux/arm64 runners
+  # (ubuntu-24.04-arm) are free for public repositories. These mirror the x86_64
+  # jobs above so the nightly/master matrix exercises the arm64 build path --
+  # e.g. the Boost PLATFORM_SUFFIX arch detection fixed in this branch (#2583).
+  linux-gui-arm:
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      runner: ubuntu-24.04-arm
+      qt-version: ''
+      variant: gui
+      build-with-python: true
+
+  linux-headless-arm:
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      runner: ubuntu-24.04-arm
+      variant: headless
+      build-testing: true
+
+  linux-gui-nonpython-arm:
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      runner: ubuntu-24.04-arm
+      variant: gui
+      build-with-python: false

--- a/Superbuild/Tests/BoostPlatformSuffix/CMakeLists.txt
+++ b/Superbuild/Tests/BoostPlatformSuffix/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Regression test for the Boost PLATFORM_SUFFIX architecture detection in
+# Superbuild/UseBoost.cmake.
+#
+# UseBoost.cmake historically probed the CPU architecture with the Apple-only
+# "-arch arm64" compiler flag. GCC/Clang on Linux reject that flag, so on
+# Linux/aarch64 the probe failed and the build fell back to the "x64" suffix --
+# baking the wrong architecture into the expected Boost library filenames.
+# See the aarch64/GB10 bug report.
+#
+# This test includes the REAL UseBoost.cmake (SCI_BOOST_LIBRARY is left unset,
+# so its per-library foreach is a no-op) and asserts that PLATFORM_SUFFIX
+# matches the host architecture. It goes red on aarch64 today and green once
+# the detection is fixed; it stays green on x86_64.
+
+cmake_minimum_required(VERSION 3.10)
+project(BoostPlatformSuffixTest C CXX)
+
+include(CheckCCompilerFlag)
+
+# Path to the file under test: <repo>/Superbuild/UseBoost.cmake
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../UseBoost.cmake)
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+  set(EXPECTED_SUFFIX "a64")
+else()
+  set(EXPECTED_SUFFIX "x64")
+endif()
+
+message(STATUS "CMAKE_SYSTEM_PROCESSOR = ${CMAKE_SYSTEM_PROCESSOR}")
+message(STATUS "PLATFORM_SUFFIX        = ${PLATFORM_SUFFIX}")
+message(STATUS "EXPECTED_SUFFIX        = ${EXPECTED_SUFFIX}")
+
+if(NOT PLATFORM_SUFFIX STREQUAL EXPECTED_SUFFIX)
+  message(FATAL_ERROR
+    "Boost PLATFORM_SUFFIX mismatch: got '${PLATFORM_SUFFIX}', "
+    "expected '${EXPECTED_SUFFIX}' for CMAKE_SYSTEM_PROCESSOR="
+    "'${CMAKE_SYSTEM_PROCESSOR}'. UseBoost.cmake misdetected the CPU "
+    "architecture.")
+endif()
+
+message(STATUS "PASS: Boost PLATFORM_SUFFIX matches host architecture.")

--- a/Superbuild/UseBoost.cmake
+++ b/Superbuild/UseBoost.cmake
@@ -9,10 +9,20 @@ if(UNIX)
   add_definitions(-DBOOST_NO_CXX11_ALLOCATOR)
 endif()
 
-check_c_compiler_flag("-arch x86_64" x86_64Supported)
-#message("x86_64Supported=${x86_64Supported}")
-check_c_compiler_flag("-arch arm64" arm64Supported)
-#message("arm64Supported=${arm64Supported}")
+# Detect whether we are targeting arm64. On Apple platforms the "-arch" driver
+# flag is valid and also covers universal/cross builds, so probe it there.
+# Elsewhere (GCC/Clang on Linux) "-arch" is rejected and both probes would fail,
+# silently mislabeling aarch64 hosts as x64 -- so derive the arch from
+# CMAKE_SYSTEM_PROCESSOR instead. See issue #2583.
+if(APPLE)
+  check_c_compiler_flag("-arch arm64" arm64Supported)
+else()
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+    set(arm64Supported TRUE)
+  else()
+    set(arm64Supported FALSE)
+  endif()
+endif()
 
 # TODO: if static runtime link is supported, then ABI tag postfix must include s
 # see:
@@ -32,7 +42,7 @@ else()
     set(DEBUG_POSTFIX "-d")
   endif()
   set(boost_LIB_PREFIX ${CMAKE_STATIC_LIBRARY_PREFIX})
-  if(${arm64Supported})
+  if(arm64Supported)
     set(PLATFORM_SUFFIX "a64")
   else()
     set(PLATFORM_SUFFIX "x64")


### PR DESCRIPTION
Fixes #2583.

On Linux/aarch64, `Superbuild/UseBoost.cmake` probed the CPU with the
Apple-Clang-only `-arch arm64` flag. GCC/Clang on Linux reject it, so **both**
arch probes failed and `PLATFORM_SUFFIX` fell back to `x64` — baking the wrong
architecture into the expected Boost static-library filenames. Reported by Cliff
Miller on an NVIDIA GB10 (Grace-Blackwell), the first Linux/aarch64 host to hit
this. The bug has been latent since M1 support landed in 2021 (`ede8cc7b`); it
never fired before because the only arm64 targets were Macs, where `-arch` is valid.

## Live arm64 build

Full `linux-build` matrix dispatched on this branch (includes the new arm64 jobs):

[![linux-build](https://github.com/SCIInstitute/SCIRun/actions/workflows/ccpp.yml/badge.svg?branch=claude/arm64-boost-suffix-fix&event=workflow_dispatch)](https://github.com/SCIInstitute/SCIRun/actions/runs/30244258460)

☝️ This badge is live — it turns **green** when the run passes (yellow while
running, red on failure). Run: https://github.com/SCIInstitute/SCIRun/actions/runs/30244258460

## Red → green

This PR is a red-green fix in three commits:

1. **Red** — a fast, dependency-free CI check (`Superbuild/Tests/BoostPlatformSuffix`)
   that `include()`s the *real* `UseBoost.cmake` and asserts `PLATFORM_SUFFIX`
   matches the host arch. On `ubuntu-24.04-arm` it failed with
   `got 'x64', expected 'a64'` — reproducing the report on GitHub CI
   ([log](https://github.com/SCIInstitute/SCIRun/actions/runs/30243813486/job/89906394098)).
2. **Green** — the fix: keep the `-arch` probe under `APPLE` (valid there, and
   covers universal/cross builds); everywhere else derive arm64 from
   `CMAKE_SYSTEM_PROCESSOR`. Also `if(arm64Supported)` instead of dereferencing a
   possibly-empty variable. macOS build path is unchanged.
3. **Coverage** — add arm64 (`ubuntu-24.04-arm`) gui/headless/nonpython jobs to
   the full `linux-build` matrix, so master pushes and the nightly cron exercise
   the arm64 superbuild going forward. Free on GitHub-hosted runners for public repos.

## Notes

- The nightly Slack summary (#2574) keys off each build workflow's `workflow_run`
  conclusion, so the new arm jobs fold into the overnight report with no extra wiring.
- The fast suffix check is configure-time only (~1s, builds no Boost) and is
  path-filtered to fire only on changes to `UseBoost.cmake` / the test / its workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
