### PR TITLE
docs(readme): modernize CI status badges (#1709)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@
 ## SCIRun 5
 <!-- https://github.com/SCIInstitute/SCIRun -->
 
-![mac-build](https://github.com/SCIInstitute/SCIRun/workflows/mac-build/badge.svg)
-![linux-build](https://github.com/SCIInstitute/SCIRun/workflows/linux-build/badge.svg)
-![windows-build](https://github.com/SCIInstitute/SCIRun/workflows/windows-build/badge.svg)
-[![regression-tests](https://github.com/SCIInstitute/SCIRun/workflows/regression-tests/badge.svg)](https://github.com/SCIInstitute/SCIRun/actions/workflows/regression-tests.yml)
-<!-- [![Coverage Status](https://coveralls.io/repos/SCIInstitute/SCIRun/badge.png)](https://coveralls.io/r/SCIInstitute/SCIRun) -->
+[![mac-build](https://github.com/SCIInstitute/SCIRun/actions/workflows/mac.yml/badge.svg)](https://github.com/SCIInstitute/SCIRun/actions/workflows/mac.yml)
+[![linux-build](https://github.com/SCIInstitute/SCIRun/actions/workflows/ccpp.yml/badge.svg)](https://github.com/SCIInstitute/SCIRun/actions/workflows/ccpp.yml)
+[![windows-build](https://github.com/SCIInstitute/SCIRun/actions/workflows/windows.yml/badge.svg)](https://github.com/SCIInstitute/SCIRun/actions/workflows/windows.yml)
+[![regression-tests](https://github.com/SCIInstitute/SCIRun/actions/workflows/regression-tests.yml/badge.svg)](https://github.com/SCIInstitute/SCIRun/actions/workflows/regression-tests.yml)
 
 ##### [Contents](#user-content-scirun-5-prototype "generated with DocToc(http://doctoc.herokuapp.com/)")
 


### PR DESCRIPTION
Refs #1709.

The README build badges were stale: they used the deprecated
`/workflows/<name>/badge.svg` URL form, only `regression-tests` was clickable,
and there was a commented-out coveralls badge for a service SCIRun no longer uses.

This updates them to the current `/actions/workflows/<file>.yml/badge.svg` form
and links each badge to its Actions page:

| badge | workflow file |
|---|---|
| mac-build | `mac.yml` |
| linux-build | `ccpp.yml` |
| windows-build | `windows.yml` |
| regression-tests | `regression-tests.yml` |

These render green/red/yellow live and now click through to the workflow runs.

**Deliberately not added** (per the issue's coverage/docs wishlist): Codecov and
ReadTheDocs badges. Neither is currently wired to publish — coverage runs in CI
but only uploads an artifact (no Codecov upload step), and there's no RTD publish
hook in the repo — so a badge for either would be misleading. Called out here as
follow-ups if/when those services are actually connected.

Note: "home page" here = the GitHub repo README. The project website
(sci.utah.edu) is maintained outside this repo and is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
