### PR TITLE
CI: add Windows Server 2025 / Visual Studio 2026 builds (#2449)

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -12,6 +12,13 @@ on:
       qt-path:
         required: false
         type: string
+      cmake-generator:
+        # Windows only: the Visual Studio generator passed to CMake. Defaults to
+        # VS 2022; set to 'Visual Studio 18 2026' for the windows-2025 image,
+        # which ships VS 2026 (v145 toolset). Requires CMake >= 4.2.
+        required: false
+        type: string
+        default: 'Visual Studio 17 2022'
       scirun-qt-min-version:
         required: false
         type: string
@@ -159,9 +166,11 @@ jobs:
           # Build arguments for cmake
           $cmakeArgs = @()
 
-          # Always use Visual Studio generator on Windows to ensure MSVC flags are used
+          # Always use a Visual Studio generator on Windows to ensure MSVC flags are used.
+          # The generator is an input (defaults to VS 2022) so the matrix can also build
+          # with VS 2026 on the windows-2025 image.
           $cmakeArgs += '-G'
-          $cmakeArgs += 'Visual Studio 17 2022'
+          $cmakeArgs += '${{ inputs.cmake-generator }}'
           $cmakeArgs += '-A'
           $cmakeArgs += 'x64'
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,3 +61,28 @@ jobs:
       variant: gui
       build-with-python: true
       artifact-name: SCIRunWindowsPythonInstaller_qt6
+
+  # ---------------------------------------------------------------------------
+  # Windows Server 2025 image, built with Visual Studio 2026 (v145 toolset).
+  # windows-2025 (== windows-latest since June 2026) ships both VS 2022 and
+  # VS 2026; selecting the 'Visual Studio 18 2026' generator exercises the newer
+  # toolchain. Kept in the nightly matrix rather than the PR tier (pr.yml) so a
+  # VS-2026-specific break can't block pull requests. See issue #2449.
+  # ---------------------------------------------------------------------------
+  windows-2025-headless-vs2026:
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      runner: windows-2025
+      cmake-generator: 'Visual Studio 18 2026'
+      variant: headless
+      build-testing: true
+
+  windows-2025-gui-qt6-vs2026:
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      runner: windows-2025
+      cmake-generator: 'Visual Studio 18 2026'
+      qt-version: '6.3.*'
+      variant: gui
+      build-with-python: false
+      artifact-name: SCIRunWindowsInstaller_qt6_vs2026

--- a/build.ps1
+++ b/build.ps1
@@ -266,17 +266,23 @@ function Get-GitBin {
 function Get-VSInfo {
     $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
     if (Test-Path $vswhere) {
-        foreach ($range in @("[17.0,18.0)", "[16.0,17.0)")) {
+        # Newest first: prefer VS 2026 (v18), then 2022 (v17), then 2019 (v16).
+        $ranges = @{ "[18.0,19.0)" = "Visual Studio 18 2026";
+                     "[17.0,18.0)" = "Visual Studio 17 2022";
+                     "[16.0,17.0)" = "Visual Studio 16 2019" }
+        foreach ($range in @("[18.0,19.0)", "[17.0,18.0)", "[16.0,17.0)")) {
             $path = & $vswhere -latest -version $range `
                 -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
                 -property installationPath 2>$null
             if ($path) {
-                $gen = if ($range -like "*17*") { "Visual Studio 17 2022" } else { "Visual Studio 16 2019" }
-                return @($gen, $path)
+                return @($ranges[$range], $path)
             }
         }
     }
     # Fallback: check well-known paths without vswhere
+    if (Test-Path "$env:ProgramFiles\Microsoft Visual Studio\2026") {
+        return @("Visual Studio 18 2026", "$env:ProgramFiles\Microsoft Visual Studio\2026")
+    }
     if (Test-Path "$env:ProgramFiles\Microsoft Visual Studio\2022") {
         return @("Visual Studio 17 2022", "$env:ProgramFiles\Microsoft Visual Studio\2022")
     }


### PR DESCRIPTION
Addresses #2449 ("Update Windows github build for 2022 and maybe 2026").

The Windows CI matrix ran only on `windows-2022` (VS 2022). Since June 2026, `windows-2025` / `windows-latest` ship **Visual Studio 2026** (v18, v145 toolset), so nothing exercised the newer toolchain.

## Changes
- **`reusable-build.yml`**: add an optional `cmake-generator` input (defaults to `Visual Studio 17 2022`) and use it in the Windows build step instead of a hardcoded generator string.
- **`windows.yml`**: add two nightly-matrix jobs on `windows-2025` built with `Visual Studio 18 2026` — headless + Qt6 GUI. Kept **out** of the slim PR tier (`pr.yml`) so a VS-2026-specific break can't block pull requests — the same nightly/PR split the mac matrix already uses.
- **`build.ps1`**: teach `Get-VSInfo` to recognize VS 18 2026 (vswhere range `[18.0,19.0)` plus the well-known install path) so local VS 2026 machines are no longer misdetected as VS 2019.

## Notes / caveats
- This is a genuine "try": the Superbuild recompiles vendored Boost/Qt/etc. with the new **v145 toolset**, which may surface build breaks. These jobs are how we'll find out.
- The `Visual Studio 18 2026` generator requires **CMake ≥ 4.2**; the `windows-2025` image ships a compatible CMake. SCIRun's own `CMAKE_MINIMUM_REQUIRED` is unchanged.
- `windows-build-script.yml` deliberately stays on `windows-2022` for now.

Validated: both workflow YAMLs parse, and `build.ps1` parses under pwsh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)