### PR TITLE
CI: make pr.yml answer for the merge queue (merge_group support)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,13 +21,31 @@ name: pr
 # regression-tests.yml / windows-build-script.yml and runs on master pushes and
 # nightly -- not on every pull request. Use the `workflow_dispatch` trigger on
 # those workflows to run the full matrix against a risky branch on demand.
+#
+# This workflow also answers for the merge queue. A queued entry is a synthetic
+# commit -- master's tip plus every PR ahead of it in the queue -- pushed to a
+# `gh-readonly-queue/master/...` ref. GitHub then waits for the same required
+# context (`ci-gate`) against that ref before landing the batch. So a queue
+# entry is a normal run of everything below, just on a ref that no PR owns.
+#
+# Two things do NOT survive the switch from `pull_request` to `merge_group`,
+# because a merge group has no pull request behind it:
+#
+#   * `github.event.pull_request.number` is empty. It appeared in the old
+#     concurrency group and in the `changes` job; both are handled below.
+#   * `cancel-in-progress` must be off here. Cancelling a queue entry reports a
+#     failed check, which ejects the PR from the queue -- the exact stall the
+#     queue is meant to remove. Pull requests still cancel as before.
 
 on:
   pull_request:
+  merge_group:
 
 concurrency:
-  group: pr-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # One group per PR, or per queue entry. `head_ref` is unique per entry, so
+  # speculative batches never cancel each other.
+  group: ${{ github.event_name }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   changes:
@@ -39,14 +57,32 @@ jobs:
     outputs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
+      # Only the merge_group path needs a working tree, and it needs full history
+      # so that base_sha is present to diff against.
+      - name: Check out merge group range
+        if: github.event_name == 'merge_group'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - name: Classify changed paths
         id: filter
         env:
           GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
-          files=$(gh pr view "${{ github.event.pull_request.number }}" \
-                    --repo "${{ github.repository }}" \
-                    --json files --jq '.files[].path')
+          # A merge group has no PR to ask about, so take the file list from the
+          # range the queue is actually proposing to land. This covers every PR
+          # in the batch, which is what we want: one code PR anywhere in a batch
+          # has to pull the whole batch through a real build.
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          else
+            files=$(gh pr view "${{ github.event.pull_request.number }}" \
+                      --repo "${{ github.repository }}" \
+                      --json files --jq '.files[].path')
+          fi
 
           echo "Changed files:"
           echo "$files"
@@ -55,6 +91,8 @@ jobs:
 
           # Fail safe towards building: an empty list, or one long enough to have
           # been truncated by the API, must not be mistaken for a docs-only PR.
+          # git diff does not truncate, but a >=100-file batch should build
+          # anyway, so the same guard is correct on both paths.
           if [ "$count" -eq 0 ] || [ "$count" -ge 100 ]; then
             docs_only=false
           elif printf '%s\n' "$files" | grep -qvE '^docs/'; then


### PR DESCRIPTION
Workflow-side prerequisite for enabling a GitHub merge queue on `master`. **This does not turn the queue on** — that is a repository setting. Without this change the queue cannot be enabled at all, because `ci-gate` would never report against a queued batch and every entry would time out.

## Why

Branch protection currently has `strict: true` ("require branches to be up to date"), with `ci-gate` as the only required context. Every merge to master invalidates every other open PR's `ci-gate`, and `ci-gate` is a full linux + mac + windows Superbuild.

Recent successful `pr.yml` runs took **210, 301, 311, 348, 409, 410 and 411 minutes** — 5–7 hours, mostly macOS queueing against the 5-slot cap. With 8 approved PRs open, `strict` turns that into ~50 hours of strictly serialized CI: merge one, six others go `BEHIND`, update each branch, wait 5–7h, merge, repeat.

A merge queue keeps the guarantee `strict` provides — nothing lands untested against the real tip — but tests a *batch* of PRs as one candidate, and never requires a PR branch to be updated. Cost per batch instead of cost per PR.

## What changed

A merge group has no pull request behind it, which breaks three things:

- **`on:` gains `merge_group:`** so `ci-gate` reports against the queued batch.
- **Concurrency group.** It keyed off `github.event.pull_request.number`, empty in a merge group — every queue entry would collide in a single group and cancel its predecessor. Now keyed off the entry's `head_ref`, with `cancel-in-progress` limited to pull requests. Cancelling a queue entry reports a failed check and ejects the PR from the queue, so it must not happen here.
- **`changes` job.** It called `gh pr view` for the file list. In a merge group it diffs `base_sha..head_sha`, classifying the batch by everything it proposes to land — one code PR anywhere in a batch pulls the whole batch through a real build. Adds a `fetch-depth: 0` checkout, on the `merge_group` path only.

`reusable-build.yml` needs no change — plain `actions/checkout@v6` resolves to the triggering ref, which in a merge group is the speculative merge commit.

## Testing

YAML parses; the `docs_only` classifier was exercised on both paths (docs-only → skip, mixed batch → build, empty → build). The `merge_group` path cannot be exercised until the queue is enabled — see below.

## Suggested queue settings, if we enable it

The 5–7h builds invert the usual advice:

- **Max entries to build concurrently: 1.** The default speculates (testing `PR1`, `PR1+2`, `PR1+2+3` in parallel). Correct for fast builds; here it would consume the entire macOS quota on candidates that get discarded.
- **Minimum group size: 5, wait time ~60 min.** This is the setting that does the work — it batches, so ~8 approved PRs become roughly one build instead of eight.
- **Maximum group size: 10.**
- **Turn `strict` off once the queue is on.** The queue supersedes it; both together reintroduce the branch-update cycle.

Two caveats worth weighing: `enforce_admins: true` means the queue becomes the only way in, with no manual merge as an escape hatch. And since this would be our first `merge_group` run, worth queueing one low-stakes PR to confirm `ci-gate` reports correctly before trusting a batch to it.

The 5–7h build remains the underlying multiplier — #2627 is what makes it cheap. This makes it cheap *per batch* in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)