### PR TITLE
Superbuild: add UPDATE_COMMAND "" to Ospray and Tetgen externals

### DIFF
--- a/Superbuild/OsprayExternal.cmake
+++ b/Superbuild/OsprayExternal.cmake
@@ -53,6 +53,10 @@ ExternalProject_Add(Ospray_external
   GIT_SUBMODULES ""
   GIT_SUBMODULES_RECURSE OFF
 
+  # EP_UPDATE_DISCONNECTED emits update and update_disconnected as siblings; under
+  # -j they race on git lock files. Missed by c552399bb.
+  UPDATE_COMMAND ""
+
   CMAKE_CACHE_ARGS
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=${CMAKE_VERBOSE_MAKEFILE}
     -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}

--- a/Superbuild/TetgenExternal.cmake
+++ b/Superbuild/TetgenExternal.cmake
@@ -56,6 +56,10 @@ ExternalProject_Add(Tetgen_external
   GIT_TAG                 ${TETGEN_GIT_TAG}
   UPDATE_DISCONNECTED     1
 
+  # Disconnected updates emit update and update_disconnected as siblings; under
+  # -j they race on git lock files. Missed by c552399bb.
+  UPDATE_COMMAND          ""
+
   SOURCE_DIR              ${_tetgen_src}
   BINARY_DIR              ${_tetgen_bin}
 


### PR DESCRIPTION
`c552399bb` added `UPDATE_COMMAND ""` to all git-based externals. Ospray and Tetgen are the two that were missed — both sit behind non-default options (`WITH_OSPRAY`, `WITH_TETGEN`), so CI never builds them and nothing flagged it.

## Why it matters

`Superbuild/Superbuild.cmake:32` sets `EP_UPDATE_DISCONNECTED TRUE`. Under that property, ExternalProject emits **two** git steps that both declare `DEPENDEES download` — `update` and `update_disconnected` — and both run the same `<name>-gitupdate.cmake` against the same clone. Serial make runs them back to back, so the second is only wasted work. Under `-j` they start together and can collide on git lock files (`.git/config`, `index.lock`).

That is the failure mode #2619 hit on Boost (`a9d9adb91`). Neither of these two has Boost's ~180 submodules, so a collision is much less likely — but the duplicate step is pointless either way, and `./build.sh --with-tetgen -jN` exercises the same code path locally.

## Verification

Configured each file standalone under CMake 4.3.3 with `EP_UPDATE_DISCONNECTED TRUE` set, before and after the change:

| | before | after |
|---|---|---|
| `Tetgen_external-gitupdate.cmake` | generated, referenced twice in `build.make` | not generated |
| `update` / `update_disconnected` | run the git update script | `No update_disconnected step for '<name>'` no-ops |

Nothing is lost by dropping the update step. The download step's generated `gitclone.cmake` checks out the pinned `GIT_TAG` and, for Tetgen, runs `git submodule update --recursive --init`. TetGen `v1.6.1` has no `.gitmodules` (checked the tag's tree), and Ospray already sets `GIT_SUBMODULES ""` — its clone script has `init_submodules FALSE` both before and after.

## Note

Tetgen's explicit `UPDATE_DISCONNECTED 1` is left in place. It's redundant alongside an empty update command, but removing it would also move the configure step's dependee from `patch_disconnected` back to `patch` — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)