### PR TITLE
Cut mac packaging from ~35 min to ~9 min (#2664)

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -108,6 +108,11 @@ jobs:
           CMD=(./build.sh)
           CMD+=("-DCMAKE_C_COMPILER_LAUNCHER=sccache")
           CMD+=("-DCMAKE_CXX_COMPILER_LAUNCHER=sccache")
+          # Default ON deletes the generated factory sources after each build, so every
+          # later `make` relinks up to SCIRun.app and re-runs its macdeployqt POST_BUILD
+          # chain -- 4x in the mac package step. Only helps incremental local builds
+          # pick up new .module files; CI is always clean. See #2664.
+          CMD+=("-DREGENERATE_MODULE_FACTORY_CODE:BOOL=OFF")
           # Variant-specific flags
           if [ "${{ inputs.variant }}" = "gui" ]; then
             # Pass Qt path (from installer or explicit), and set SCIRUN_QT_MIN_VERSION appropriately
@@ -175,6 +180,9 @@ jobs:
           $cmakeArgs = @()
           $cmakeArgs += "-DCMAKE_C_COMPILER_LAUNCHER=sccache"
           $cmakeArgs += "-DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+
+          # As in the Linux/macOS step above: avoids a needless relink cascade. See #2664.
+          $cmakeArgs += "-DREGENERATE_MODULE_FACTORY_CODE:BOOL=OFF"
 
           # Always use a Visual Studio generator on Windows to ensure MSVC flags are used.
           # The generator is an input (defaults to VS 2022) so the matrix can also build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -961,7 +961,15 @@ SET(CPACK_PACKAGE_INSTALL_DIRECTORY "${APPLICATION_NAME}_${SCIRUN_VERSION_MAJOR}
 
 # other platform settings will be built up from here
 IF(APPLE)
-  SET(CPACK_GENERATOR "productbuild;TGZ")
+  # Each generator runs its own preinstall pass, which on macOS re-runs the ~7.5 min
+  # macdeployqt bundle chain. Nothing consumed the tarball. See #2664.
+  OPTION(SCIRUN_PACKAGE_TGZ "Also build a .tar.gz alongside the macOS installer" OFF)
+  MARK_AS_ADVANCED(SCIRUN_PACKAGE_TGZ)
+  IF(SCIRUN_PACKAGE_TGZ)
+    SET(CPACK_GENERATOR "productbuild;TGZ")
+  ELSE()
+    SET(CPACK_GENERATOR "productbuild")
+  ENDIF()
   SET(CPACK_TOPLEVEL_TAG "")
   IF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
    SET(CPACK_INSTALL_PREFIX "/" CACHE PATH "Install path prefix, prepended onto install directories." FORCE)

--- a/src/Interface/Application/CMakeLists.txt
+++ b/src/Interface/Application/CMakeLists.txt
@@ -132,8 +132,11 @@ QT_WRAP_UI(Interface_Application_FORMS_HEADERS "${Interface_Application_FORMS}")
 QT_WRAP_CPP(Interface_Application_HEADERS_MOC "${Interface_Application_HEADERS}")
 QT_ADD_RESOURCES(Interface_Application_RESOURCES_RCC "${Interface_Application_RESOURCES}")
 
+# Scoped to the one source that reads it: directory-wide ADD_DEFINITIONS made the
+# packaging step's -DBUILD_BUNDLE=ON reconfigure recompile all ~70 sources here. #2664
 IF(BUILD_BUNDLE)
-  ADD_DEFINITIONS(-DBUILD_BUNDLE)
+  SET_SOURCE_FILES_PROPERTIES(SCIRunMainWindowSlotsPrivate.cc
+    PROPERTIES COMPILE_DEFINITIONS BUILD_BUNDLE)
 ENDIF()
 
 SCIRUN_ADD_LIBRARY(Interface_Application


### PR DESCRIPTION
Fixes tasks 1-3 of #2664. The PR-installer question (task 4 there) is deliberately untouched.

The `Package (optional - Unix/macOS)` step was **34.6 min of a 78 min `mac-gui` job**, and 30 of those minutes were the `SCIRun.app` POST_BUILD bundle chain — `macdeployqt` plus `install_name_tool` over ~2,600 dependency edges — running **four separate times** at ~7.5 min each.

Worth stating up front, because it's the intuitive suspect: **compression was never the problem.** productbuild and tar.gz together account for **29 seconds**. Full measurements are in #2664.

## The three causes

**1. The factory-code delete hack forces a relink cascade on every `make`.**

`REGENERATE_MODULE_FACTORY_CODE` (default `ON`) deletes the three generated factory `.cc` files as a POST_BUILD step, so their custom-command OUTPUT is *always* missing. Every later `make` regenerates → recompiles → relinks up through `Interface_Application` to `SCIRun.app`, and relinking the bundle target re-fires its POST_BUILD chain. `make package` invokes make three more times (`all`, plus one preinstall per CPack generator) — hence four passes.

The flag exists so incremental local builds notice newly added `.module` files, since the custom command depends on `MakeModuleFactory` rather than on the config files. CI configures a clean build directory every run (only sccache is cached), so it buys nothing there. **Turned off in CI only — the default is unchanged for local development.**

**2. Two CPack generators, one of which was thrown away.**

`CPACK_GENERATOR` was `"productbuild;TGZ"` on Apple, and each generator runs its own full preinstall pass. Nothing consumed the tarball — CI uploads only `SCIRun-*-Darwin.pkg`, and no script in the repo references the `.tar.gz`. Now productbuild alone, with a new advanced `SCIRUN_PACKAGE_TGZ=ON` to opt back in rather than deleting the capability.

**3. `BUILD_BUNDLE` recompiled 70 files to serve one `#ifdef`.**

It was applied with directory-wide `ADD_DEFINITIONS`, so the packaging step's `-DBUILD_BUNDLE=ON` reconfigure changed the command line for every source in `Interface/Application` and missed sccache on all of them. The only consumer is a two-line path selection in `SCIRunMainWindowSlotsPrivate.cc`. Now scoped to that one source file.

## Expected effect

| | before | after |
|---|---|---|
| bundle chain passes | 4 × ~7.5 min | 1 |
| TGZ preinstall + compress | 7 m 36 s | 0 |
| `BUILD_BUNDLE` recompile | 2 m 39 s | ~0 |
| **step total** | **34.6 min** | **~8-9 min** |

All three are correct for nightly and release too — none is a PR-only shortcut.

## Verification

Configured the inner project in a scratch directory against prebuilt externals:

- `CPACK_GENERATOR` is `"productbuild"`. The two remaining TGZ mentions in `CPackConfig.cmake` are `CPACK_SOURCE_GENERATOR`, which only the `package_source` target uses.
- The factory-delete POST_BUILD rule is gone from `Modules_Factory.dir/build.make` (0 matches).
- `BUILD_BUNDLE` appears on **exactly 1 of 210** objects, as a per-source define in `flags.make`.
- Compiled that object both ways: with the flag on it contains no `SCIRun_test` string, with it off it does — the `#ifdef` still resolves correctly in both directions.
- `repair_package.sh` is still generated.

**Not verified, and worth knowing:** no full build was run and no `.pkg` was actually produced, so the ~9 min figure is arithmetic from the measured per-pass timings rather than an observed run — the real number arrives with the first CI run on this branch. Fix 1's effect is confirmed structurally (the delete rule is absent from the generated makefile) rather than by watching a second `make` stay quiet.

## Reviewer notes

- The Windows build picks up fix 1 as well. It should be neutral-to-positive there, but Windows packaging was not part of this investigation — worth a glance at the `windows-gui-qt6` job time on the first run.
- Please sanity-check the produced `.pkg` installs and launches before this is relied on for a release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
