### PR TITLE
CI: add a Qt6 Linux build to the PR tier

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -76,6 +76,24 @@ jobs:
       variant: gui
       build-with-python: true
 
+  # Qt6 on Linux. Every other Linux job here and in ccpp.yml autodetects
+  # qtbase5-dev, so before this job the only Qt6 compile coverage anywhere was
+  # mac-gui and windows-gui-qt6 -- the two slowest, scarcest runners.
+  #
+  # Deliberately absent from ci-gate's `needs` for now: this config has never
+  # been built, so it stays advisory until it has a green history. Promoting it
+  # (and dropping mac/windows to path-triggered) is the follow-up.
+  linux-gui-qt6:
+    needs: changes
+    if: needs.changes.outputs.docs_only == 'false'
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      runner: ubuntu-latest
+      qt-version: '6.3.*'
+      scirun-qt-min-version: '6.3.1'
+      variant: gui
+      build-with-python: true
+
   mac-gui:
     needs: changes
     if: needs.changes.outputs.docs_only == 'false'


### PR DESCRIPTION
## What

Adds `linux-gui-qt6` to `pr.yml`: an ubuntu-latest GUI build against Qt `6.3.*`, `build-with-python: true`.

No changes to `reusable-build.yml` — `jurplel/install-qt-action` already handles Linux, and the `qt-version` input path (`-DQt_PATH="$QT_ROOT_DIR"`) is platform-agnostic.

## Why

There is no Qt6 Linux build anywhere in CI today.

- Every Linux GUI job in `pr.yml` and `ccpp.yml` passes `qt-version: ''`, which falls through to autodetecting `qtbase5-dev` — a **Qt 5** build.
- `linux-unit-tests` is `variant: headless`, and `BUILD_HEADLESS` skips `ADD_SUBDIRECTORY(Interface)` outright, so it compiles no Qt at all.

That leaves `mac-gui` (6.10.2) and `windows-gui-qt6` (6.3.*) as the only places Qt6 is compiled — the two slowest runners in the matrix, one of them behind GitHub's 5-slot macOS cap.

The reason this is worth fixing now is the required-check set. `master` has `required_status_checks.strict: true` with `ci-gate` as the sole required context, so every merge invalidates every other open PR and forces a full re-run. `ci-gate`'s long pole is `windows-gui-qt6` at ~137 min plus macOS queueing — 4h05m on run 31078669153, which also cancelled the two runs before it.

A required gate built from two ubuntu jobs — Qt6 GUI plus headless-with-tests — would cost roughly an hour instead, on the platform with no daily human coverage (Dan builds macOS daily, Yong develops on Windows). But that gate can't be assembled from the jobs that exist today, because neither Linux job compiles Qt6. This PR is the missing piece.

## Scope

Deliberately **not** wired into `ci-gate`'s `needs`. This config has never been built, so it stays advisory until it has a green history. Promoting it — and dropping `mac-gui`/`windows-gui-qt6` to path-triggered on build-system changes — is a follow-up, and needs no branch-protection edit since `ci-gate` keeps its name.

Qt5 keeps its per-PR coverage via the unchanged `linux-gui` job.

## Risk

`6.3.*` matches `windows-gui-qt6` and is the declared `SCIRUN_QT_MIN_VERSION` floor, so this also checks that the floor is honest. The open question is whether Qt 6.3.2's Linux binaries (built against Ubuntu 20.04) are happy on `ubuntu-latest` = 24.04. If they aren't, the fix is bumping to a 6.5/6.8 LTS here and reconsidering whether 6.3.1 is still a realistic floor — either outcome is useful information. This job's own run on this PR is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)