### PR TITLE
CI: narrow ci-gate to two Linux jobs on non-platform PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,11 @@ name: pr
 #     contexts directly re-creates the problem in rule 1 as soon as one of them
 #     is filtered or renamed.
 #
+# Within this workflow there are two tiers. Two Linux jobs -- linux-gui-qt6 and
+# linux-unit-tests -- run on every non-docs PR and are what ci-gate normally
+# waits on. mac-gui and windows-gui-qt6 join them only when the PR touches
+# build-system, CI, or platform-specific paths (see `platform_risk` below).
+#
 # The full matrix (all the mac-headless-*, windows-gui-python-*, regression and
 # coverage variants) lives in ccpp.yml / mac.yml / windows.yml /
 # regression-tests.yml / windows-build-script.yml and runs on master pushes and
@@ -38,6 +43,7 @@ jobs:
       pull-requests: read
     outputs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
+      platform_risk: ${{ steps.filter.outputs.platform_risk }}
     steps:
       - name: Classify changed paths
         id: filter
@@ -63,8 +69,27 @@ jobs:
             docs_only=true
           fi
 
+          # Does this PR touch anything that can behave differently per platform?
+          # Build system, CI, vendored externals, and the macOS bundle glue. C++
+          # under src/ that compiles on gcc against Qt6 is not in this set -- that
+          # is the bet this filter makes, and windows.yml/mac.yml on master push
+          # plus the nightly matrix are what catch it when the bet is wrong.
+          #
+          # Only the two top-level CMakeLists count: those hold the APPLE/WIN32
+          # blocks. Nested ones are source lists, and matching them would drag
+          # every new module into the full matrix for no reason.
+          if [ "$count" -eq 0 ] || [ "$count" -ge 100 ]; then
+            platform_risk=true
+          elif printf '%s\n' "$files" | grep -qE '^(Superbuild/|\.github/|CMake/|src/Externals/|src/Main/)|^(src/)?CMakeLists\.txt$|\.cmake$|^build\.(sh|ps1)$'; then
+            platform_risk=true
+          else
+            platform_risk=false
+          fi
+
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+          echo "platform_risk=$platform_risk" >> "$GITHUB_OUTPUT"
           echo "docs_only=$docs_only"
+          echo "platform_risk=$platform_risk"
 
   linux-gui:
     needs: changes
@@ -78,11 +103,8 @@ jobs:
 
   # Qt6 on Linux. Every other Linux job here and in ccpp.yml autodetects
   # qtbase5-dev, so before this job the only Qt6 compile coverage anywhere was
-  # mac-gui and windows-gui-qt6 -- the two slowest, scarcest runners.
-  #
-  # Deliberately absent from ci-gate's `needs` for now: this config has never
-  # been built, so it stays advisory until it has a green history. Promoting it
-  # (and dropping mac/windows to path-triggered) is the follow-up.
+  # mac-gui and windows-gui-qt6 -- the two slowest, scarcest runners. Pairing it
+  # with linux-unit-tests is what lets those two leave the always-on set below.
   linux-gui-qt6:
     needs: changes
     if: needs.changes.outputs.docs_only == 'false'
@@ -94,9 +116,18 @@ jobs:
       variant: gui
       build-with-python: true
 
+  # mac and windows run only when the PR touches something that can diverge by
+  # platform. They stay in ci-gate's `needs`, so when they do run the gate waits
+  # on them exactly as before; when they are skipped, branch protection counts
+  # that as passing and the gate falls through to the two Linux jobs.
+  #
+  # They are here rather than always-on because ci-gate is a *strict* required
+  # check: every merge to master invalidates every other PR and re-runs all of
+  # this. windows-gui-qt6 alone is 104-139 min against ~63 for linux-gui-qt6,
+  # and macOS-latest is capped at 5 concurrent jobs repo-wide.
   mac-gui:
     needs: changes
-    if: needs.changes.outputs.docs_only == 'false'
+    if: needs.changes.outputs.docs_only == 'false' && needs.changes.outputs.platform_risk == 'true'
     uses: ./.github/workflows/reusable-build.yml
     with:
       runner: macOS-latest
@@ -108,7 +139,7 @@ jobs:
 
   windows-gui-qt6:
     needs: changes
-    if: needs.changes.outputs.docs_only == 'false'
+    if: needs.changes.outputs.docs_only == 'false' && needs.changes.outputs.platform_risk == 'true'
     uses: ./.github/workflows/reusable-build.yml
     with:
       runner: windows-2022
@@ -142,13 +173,14 @@ jobs:
   ci-gate:
     name: ci-gate
     if: always()
-    needs: [changes, linux-gui, mac-gui, windows-gui-qt6, linux-unit-tests]
+    needs: [changes, linux-gui, linux-gui-qt6, mac-gui, windows-gui-qt6, linux-unit-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Report upstream results
         run: |
           echo "changes:          ${{ needs.changes.result }}"
           echo "linux-gui:        ${{ needs.linux-gui.result }}"
+          echo "linux-gui-qt6:    ${{ needs.linux-gui-qt6.result }}"
           echo "mac-gui:          ${{ needs.mac-gui.result }}"
           echo "windows-gui-qt6:  ${{ needs.windows-gui-qt6.result }}"
           echo "linux-unit-tests: ${{ needs.linux-unit-tests.result }}"


### PR DESCRIPTION
## What

`mac-gui` and `windows-gui-qt6` now run on a PR only when it touches build-system, CI, or platform-specific paths. Ordinary PRs gate on `linux-gui-qt6` + `linux-unit-tests`.

```
ordinary PR:   linux-gui-qt6 (~63) + linux-unit-tests (~50)   -> ci-gate ~63 min
platform PR:   + mac-gui (~43) + windows-gui-qt6 (104-139)    -> ci-gate ~139 min, i.e. today
```

Both jobs stay in `ci-gate`'s `needs`. When they run, the gate waits on them exactly as it does now. When they're skipped, branch protection counts that as passing and the gate falls through to the two Linux jobs. Risky PRs keep the full guarantee automatically — no label to remember, no second advisory context.

`ci-gate` keeps its name and stays the sole required context, so **no branch-protection change is needed**, and this is one commit to revert.

## Why

`ci-gate` is a strict required check (`required_status_checks.strict: true`), so every merge to `master` invalidates every other open PR and re-runs everything the gate waits on. What it waits on is dominated by `windows-gui-qt6` at 104–139 min, with `macOS-latest` capped at 5 concurrent jobs repo-wide behind it — run 31078669153 queued 4h05m for a mac runner and cancelled the two runs before it.

This wasn't possible until #2666. There was no Qt6 build anywhere outside mac and windows, and `linux-unit-tests` is `variant: headless`, which skips `src/Interface` entirely — so no combination of the pre-existing Linux jobs could stand in for them.

`linux-gui-qt6` now has **8 green runs across 5 branches, 58–63 min**, including the Qt6 deprecation PRs (#2659, #2660) that are precisely what this gate has to protect.

## The path filter

Selects on `Superbuild/`, `.github/`, `CMake/`, `src/Externals/`, `src/Main/`, `*.cmake`, `build.sh|ps1`, and the two **top-level** `CMakeLists.txt`.

Nested `CMakeLists.txt` are deliberately excluded. An earlier draft matched all of them and classified 13 of 18 open PRs as platform-risky, which is useless — adding a module means editing a source list, and that says nothing about platform behaviour. The two top-level files are the ones holding the `APPLE`/`WIN32` blocks.

Against the 18 open PRs the narrowed filter gives **8 full-matrix / 10 Linux-only**, each selection with a visible cause:

| PR | trigger |
|---|---|
| #2667 | `Superbuild/Superbuild.cmake` |
| #2644, #2576, #2575 | `.github/workflows/reusable-build.yml` |
| #2603, #2602 | `src/CMakeLists.txt` |
| #2658 | `.github/workflows/nightly-slack.yml` |
| #2643 | `.github/workflows/pr.yml` |

The 10 skipped are pure C++/Qt/module work.

## What this accepts

**MSVC is the strictest of the three compilers** — missing includes and two-phase name lookup pass gcc and fail cl. That's the real exposure. Mitigations: Yong develops on Windows day to day, `windows.yml` runs the full matrix on every `master` push, and the nightly runs it again.

**macOS** is well covered — daily local builds plus `mac.yml` on master push.

Honest about the ceiling: most of the last 20 *merged* PRs would still take the full matrix, because recent merge history is mostly CI and build-system work. The savings land on module and GUI PRs, which is what the open queue currently is.

Any PR can still be given the full matrix on demand via `workflow_dispatch` on `mac.yml` / `windows.yml`, or by pushing a trivial touch to a filtered path.

Follow-up to #2666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)