### PR TITLE
CI: fix nightly Slack summary parsing, and make coverage actually instrument

### DIFF
--- a/.github/workflows/nightly-slack.yml
+++ b/.github/workflows/nightly-slack.yml
@@ -12,16 +12,17 @@ name: nightly-slack
 #
 #  * `workflow_run` only fires for workflow files that live on the DEFAULT
 #    branch. This notifier therefore does nothing until it is merged to master,
-#    and cannot be exercised from a PR branch. That is expected for nightly
-#    infrastructure -- there is no way to unit-test a workflow_run trigger from a
-#    feature branch.
+#    and cannot be exercised from a PR branch. That is why the payload is built
+#    by scripts/ci/slack_test_summary.py rather than inline shell -- the script
+#    runs against downloaded artifacts locally, which is the only way any of this
+#    gets tested before it is live.
 #
 #  * It reports the REAL ctest pass/fail counts, not just the job conclusion.
 #    The ctest steps in reusable-build.yml carry `continue-on-error: true`, so
 #    regression-tests reports "success" even when hundreds of cases fail. The
-#    counts are recovered by downloading that run's `test-results-*` artifacts
-#    and parsing the "N% tests passed, M tests failed out of K" summary lines.
-#    A green job with failing tests is flagged yellow rather than green.
+#    counts (and the failing test names) come from the junit-*.xml files in that
+#    run's `test-results-*` artifacts. A green job with failing tests is flagged
+#    yellow rather than green.
 #
 #  * Filtered to `event == 'schedule'`: only the nightly cron pings Slack. Master
 #    pushes and workflow_dispatch runs do not (pushes still get GitHub's default
@@ -55,6 +56,14 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'schedule' }}
     runs-on: ubuntu-latest
     steps:
+      # Only for scripts/ci/slack_test_summary.py. workflow_run always resolves
+      # the workflow -- and therefore this checkout -- against the default
+      # branch, so this is master's copy of the script, never a PR's.
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
       - name: Download test-results artifacts (best effort)
         env:
           GH_TOKEN: ${{ github.token }}
@@ -78,48 +87,8 @@ jobs:
           WF_SHA: ${{ github.event.workflow_run.head_sha }}
           WF_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          short_sha="${WF_SHA:0:9}"
-
-          # Collect ctest summary lines from any downloaded results files.
-          # Filenames: unit-test-results.txt / regression-test-results.txt,
-          # under a dir named test-results-<OS>-<variant>.
-          test_lines=""
-          any_fail=0
-          shopt -s nullglob
-          for f in artifacts/*/*-test-results.txt; do
-            art="$(basename "$(dirname "$f")")"        # test-results-Linux-headless
-            label="${art#test-results-}"               # Linux-headless
-            kind="$(basename "$f")"; kind="${kind%%-test-results.txt}"   # unit | regression
-            summary="$(grep -Eo '[0-9]+% tests passed, [0-9]+ tests failed out of [0-9]+' "$f" | tail -n1)"
-            [ -z "$summary" ] && continue
-            failed="$(printf '%s' "$summary" | grep -Eo '^[0-9]+% tests passed, [0-9]+' | grep -Eo '[0-9]+$')"
-            [ "${failed:-0}" -gt 0 ] && any_fail=1
-            test_lines="${test_lines}\n• ${label} ${kind}: ${summary}"
-          done
-
-          # Emoji: honor the real conclusion, but downgrade a green job to yellow
-          # when its continue-on-error tests actually failed underneath.
-          case "$WF_CONCLUSION" in
-            success)   emoji=":large_green_circle:";;
-            failure)   emoji=":red_circle:";;
-            cancelled) emoji=":black_circle:";;
-            *)         emoji=":white_circle:";;
-          esac
-          if [ "$any_fail" -eq 1 ] && [ "$WF_CONCLUSION" = "success" ]; then
-            emoji=":large_yellow_circle:"
-          fi
-
-          header="${emoji} *${WF_NAME}* nightly — ${WF_CONCLUSION}"
-          footer="<${WF_URL}|View run> · \`${short_sha}\` (${WF_BRANCH})"
-          if [ -n "$test_lines" ]; then
-            text="${header}${test_lines}\n${footer}"
-          else
-            text="${header}\n${footer}"
-          fi
-
-          # Build the JSON with jq so newlines and any special characters in the
-          # summary are escaped correctly. printf %b expands the \n separators.
-          jq -n --arg t "$(printf '%b' "$text")" '{text: $t}' > payload.json
+          set -euo pipefail
+          python3 scripts/ci/slack_test_summary.py artifacts > payload.json
           echo "Payload:"
           cat payload.json
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -422,6 +422,10 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: coverage-report-${{ runner.os }}
+          # `error`, not the default `warn`: the step above is continue-on-error
+          # (tests legitimately fail), so a coverage.sh that produced nothing
+          # otherwise reports success and silently uploads no artifact.
+          if-no-files-found: error
           path: |
             bin/SCIRun/coverage/summary.txt
             bin/SCIRun/coverage/html

--- a/scripts/ci/slack_test_summary.py
+++ b/scripts/ci/slack_test_summary.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Build a Slack Block Kit payload summarising a nightly run's test results.
+
+Reads the `test-results-*` artifacts downloaded from a workflow run and writes
+Slack JSON to stdout. Used by .github/workflows/nightly-slack.yml; kept as a
+standalone script because `workflow_run` triggers cannot be exercised from a
+branch, so this is the only part of that workflow that can be tested at all:
+
+    gh run download <run-id> --dir artifacts --pattern 'test-results-*'
+    WF_NAME=regression-tests WF_CONCLUSION=success \\
+      python3 scripts/ci/slack_test_summary.py artifacts
+
+Artifact layout is NOT uniform across platforms. The Unix upload step mixes an
+absolute path (/tmp/unit-test-results.txt) with workspace-relative ones, so
+upload-artifact roots the archive at / and the files land under
+`test-results-Linux-headless/home/runner/work/...`; the all-relative Windows
+paths land directly under the artifact directory. Hence rglob, not glob.
+"""
+
+import json
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+# Failing test names per report, before collapsing into "...and N more". Slack
+# truncates a context element at 3000 chars and the names here run ~90.
+MAX_NAMES = 5
+
+CTEST_SUMMARY = re.compile(
+    r"(\d+)% tests passed, (\d+) tests failed out of (\d+)")
+
+
+class Report:
+    """One junit file: a (job, kind) pair such as Linux-headless / regression."""
+
+    def __init__(self, label, kind):
+        self.label = label
+        self.kind = kind
+        self.total = 0
+        self.failed = 0
+        self.skipped = 0
+        self.names = []
+
+    @property
+    def passed(self):
+        return self.total - self.failed - self.skipped
+
+
+def parse_junit(path, label, kind):
+    root = ET.parse(path).getroot()
+    r = Report(label, kind)
+    # ctest's own attributes are authoritative; `disabled` tests are counted in
+    # `tests` here but excluded from ctest's console "out of N", which is why
+    # the two disagree by exactly the disabled count.
+    r.total = int(root.get("tests", 0))
+    r.failed = int(root.get("failures", 0))
+    r.skipped = int(root.get("disabled", 0)) + int(root.get("skipped", 0))
+    r.names = [tc.get("name") for tc in root.iter("testcase")
+               if tc.get("status") == "fail" or tc.find("failure") is not None]
+    return r
+
+
+def parse_ctest_text(path, label, kind):
+    """Fallback for a run whose junit file is missing (ctest died early)."""
+    m = None
+    for m in CTEST_SUMMARY.finditer(path.read_text(errors="replace")):
+        pass
+    if m is None:
+        return None
+    r = Report(label, kind)
+    r.failed = int(m.group(2))
+    r.total = int(m.group(3))
+    return r
+
+
+def collect(artifacts_dir):
+    reports = []
+    for art in sorted(p for p in artifacts_dir.iterdir() if p.is_dir()):
+        label = art.name.removeprefix("test-results-")
+        for kind in ("unit", "regression"):
+            junit = next(art.rglob(f"junit-{kind}.xml"), None)
+            if junit is not None:
+                try:
+                    reports.append(parse_junit(junit, label, kind))
+                    continue
+                except ET.ParseError as exc:
+                    print(f"warning: {junit}: {exc}", file=sys.stderr)
+            text = next(art.rglob(f"{kind}-test-results.txt"), None)
+            if text is not None:
+                fallback = parse_ctest_text(text, label, kind)
+                if fallback is not None:
+                    reports.append(fallback)
+    return reports
+
+
+def emoji_for(conclusion, any_failed):
+    # Honour the real conclusion, but downgrade a green job to yellow when its
+    # continue-on-error test steps actually failed underneath it.
+    base = {
+        "success": ":large_green_circle:",
+        "failure": ":red_circle:",
+        "cancelled": ":black_circle:",
+    }.get(conclusion, ":white_circle:")
+    if any_failed and conclusion == "success":
+        return ":large_yellow_circle:"
+    return base
+
+
+def build(reports, env):
+    name = env.get("WF_NAME", "workflow")
+    conclusion = env.get("WF_CONCLUSION", "unknown")
+    url = env.get("WF_URL", "")
+    sha = env.get("WF_SHA", "")[:9]
+    branch = env.get("WF_BRANCH", "")
+
+    any_failed = any(r.failed for r in reports)
+    header = f"{emoji_for(conclusion, any_failed)} *{name}* nightly — {conclusion}"
+
+    blocks = [{"type": "section",
+               "text": {"type": "mrkdwn", "text": header}}]
+
+    # One field per report, two columns. Slack caps a section at 10 fields, so
+    # chunk rather than assume the matrix stays small.
+    fields = []
+    for r in reports:
+        mark = "❌" if r.failed else "✅"
+        fields.append({
+            "type": "mrkdwn",
+            "text": (f"*{r.label}* · {r.kind}\n"
+                     f"{mark} {r.failed} failed / {r.total}"
+                     + (f" · {r.skipped} skipped" if r.skipped else "")),
+        })
+    for i in range(0, len(fields), 10):
+        blocks.append({"type": "section", "fields": fields[i:i + 10]})
+
+    for r in reports:
+        if not r.names:
+            continue
+        shown = r.names[:MAX_NAMES]
+        more = len(r.names) - len(shown)
+        listing = "\n".join(f"• {n}" for n in shown)
+        if more:
+            listing += f"\n• …and {more} more"
+        blocks.append({
+            "type": "context",
+            "elements": [{"type": "mrkdwn",
+                          "text": f"*{r.label} {r.kind}*\n{listing}"}],
+        })
+
+    footer = f"<{url}|View run>"
+    if sha:
+        footer += f" · `{sha}`"
+    if branch:
+        footer += f" ({branch})"
+    blocks.append({"type": "context",
+                   "elements": [{"type": "mrkdwn", "text": footer}]})
+
+    # Slack hard-caps a message at 50 blocks; drop failure listings from the
+    # middle rather than letting the whole post 400 out.
+    if len(blocks) > 50:
+        blocks = blocks[:49] + blocks[-1:]
+
+    # `text` is the notification/fallback line, not shown in-channel when
+    # blocks are present.
+    return {"text": f"{name} nightly — {conclusion}", "blocks": blocks}
+
+
+def main():
+    artifacts_dir = Path(sys.argv[1] if len(sys.argv) > 1 else "artifacts")
+    reports = collect(artifacts_dir) if artifacts_dir.is_dir() else []
+    json.dump(build(reports, os.environ), sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -628,6 +628,44 @@ MARK_AS_ADVANCED(CMAKE_LIBRARY_OUTPUT_DIRECTORY CMAKE_RUNTIME_OUTPUT_DIRECTORY)
 
 SET(BUILD_FROM_TOP_LEVEL 1)
 
+########################################################################
+# Coverage instrumentation.
+#
+# Must precede the ADD_SUBDIRECTORY calls below: CMAKE_CXX_FLAGS is captured by
+# each subdirectory as it is added, so setting it further down the file compiles
+# and links every SCIRun target without instrumentation while still printing the
+# "enabled" message. That produced zero .profraw files and an empty nightly
+# coverage artifact.
+
+OPTION(ENABLE_GCOV_DATA_FILES "Creates .gcda and .gcno files for coverage" OFF)
+MARK_AS_ADVANCED(ENABLE_GCOV_DATAFILES)
+
+IF(ENABLE_GCOV_DATA_FILES)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
+ENDIF()
+
+# Clang source-based coverage (recommended on macOS / any Clang toolchain).
+# Build with -DENABLE_COVERAGE=ON, run tests via scripts/coverage.sh, which
+# sets LLVM_PROFILE_FILE=<dir>/%p.profraw (one .profraw per test process),
+# merges with llvm-profdata, and reports with llvm-cov. Unlike the gcov option
+# above, the instrumentation flags must also be applied at link time so the
+# profile runtime is linked into every shared library.
+OPTION(ENABLE_COVERAGE "Build with Clang source-based code coverage instrumentation" OFF)
+IF(ENABLE_COVERAGE)
+  IF(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    MESSAGE(WARNING "ENABLE_COVERAGE uses Clang source-based coverage but the compiler is ${CMAKE_CXX_COMPILER_ID}; use ENABLE_GCOV_DATA_FILES instead.")
+  ENDIF()
+  SET(SCIRUN_COVERAGE_FLAGS "-fprofile-instr-generate -fcoverage-mapping")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCIRUN_COVERAGE_FLAGS} -g")
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SCIRUN_COVERAGE_FLAGS} -g")
+  SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${SCIRUN_COVERAGE_FLAGS}")
+  SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${SCIRUN_COVERAGE_FLAGS}")
+  MESSAGE(STATUS "Code coverage instrumentation enabled (Clang source-based). Best with a Debug build.")
+ENDIF()
+
+########################################################################
+
 ADD_SUBDIRECTORY(Externals)
 IF(NOT BUILD_HEADLESS)
   ADD_SUBDIRECTORY(Interface)
@@ -1035,32 +1073,5 @@ ENDIF()
 
 INCLUDE(CPack)
 
-########################################################################
-#GCov
-
-OPTION(ENABLE_GCOV_DATA_FILES "Creates .gcda and .gcno files for coverage" OFF)
-MARK_AS_ADVANCED(ENABLE_GCOV_DATAFILES)
-
-IF(ENABLE_GCOV_DATA_FILES)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
-  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
-ENDIF()
-
-# Clang source-based coverage (recommended on macOS / any Clang toolchain).
-# Build with -DENABLE_COVERAGE=ON, run tests via scripts/coverage.sh, which
-# sets LLVM_PROFILE_FILE=<dir>/%p.profraw (one .profraw per test process),
-# merges with llvm-profdata, and reports with llvm-cov. Unlike the gcov option
-# above, the instrumentation flags must also be applied at link time so the
-# profile runtime is linked into every shared library.
-OPTION(ENABLE_COVERAGE "Build with Clang source-based code coverage instrumentation" OFF)
-IF(ENABLE_COVERAGE)
-  IF(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    MESSAGE(WARNING "ENABLE_COVERAGE uses Clang source-based coverage but the compiler is ${CMAKE_CXX_COMPILER_ID}; use ENABLE_GCOV_DATA_FILES instead.")
-  ENDIF()
-  SET(SCIRUN_COVERAGE_FLAGS "-fprofile-instr-generate -fcoverage-mapping")
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCIRUN_COVERAGE_FLAGS} -g")
-  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SCIRUN_COVERAGE_FLAGS} -g")
-  SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${SCIRUN_COVERAGE_FLAGS}")
-  SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${SCIRUN_COVERAGE_FLAGS}")
-  MESSAGE(STATUS "Code coverage instrumentation enabled (Clang source-based). Best with a Debug build.")
-ENDIF()
+# Coverage options moved above the ADD_SUBDIRECTORY calls -- they had no effect
+# down here. See the "Coverage instrumentation" block there.


### PR DESCRIPTION
Two independent nightly-reporting bugs, found while looking at run [31250403273](https://github.com/SCIInstitute/SCIRun/actions/runs/31250403273). Both reported success while producing nothing.

## 1. The Slack summary only ever reported Windows

`nightly-slack.yml` globbed `artifacts/*/*-test-results.txt`. The artifact layout is not uniform:

```
test-results-Windows-headless/unit-test-results.txt          ← matched
test-results-Linux-headless/tmp/unit-test-results.txt        ← one level too deep
test-results-macOS-gui/tmp/unit-test-results.txt             ← one level too deep
```

The Unix upload step in `reusable-build.yml` mixes an absolute path (`/tmp/unit-test-results.txt`) with workspace-relative ones, so `upload-artifact` computes `/` as the least common ancestor and preserves the leading `tmp/`. Windows uses all-relative paths, so its LCA is the workspace. Linux and macOS counts have been silently missing from every nightly post.

### What changed

The inline shell is replaced by `scripts/ci/slack_test_summary.py`, which walks with `rglob` and reads the `junit-*.xml` files already sitting in those artifacts instead of grepping ctest's console summary. That yields failing test *names*, not just counts — which is the part worth seeing at 8am. On the run above:

| Job | Unit | Regression |
|---|---|---|
| Linux-headless | 1 failed / 488 | 8 failed / 247 |
| Windows-headless | 1 failed / 489 | 8 failed / 247 |
| macOS-gui | 4 failed / 490 | 12 failed / 309 |

Linux and Windows fail the *same* 8 regression cases; macOS fails a disjoint 12, mostly rendering. The single failing unit suite is different on all three (`Algorithms_Field_Tests` / `Core_Python_Tests` / four `.Test.ImportNetwork.*`). None of that could reach Slack before.

Output is Block Kit: a per-job field grid, a context block per failing report with up to 5 names and an "…and N more" tail, then the run link. The yellow-circle downgrade for hidden `continue-on-error` failures is preserved.

Note the junit totals (488/489/490) exceed ctest's console "out of 479" because ctest excludes disabled tests from its denominator. The XML count is the honest one.

### Why a script rather than inline YAML

`workflow_run` only fires for workflows on the default branch, so this notifier cannot be exercised from a PR — including this one. A standalone script can be run against downloaded artifacts, which is the only way any of it gets tested before going live:

```bash
gh run download 31250403273 --dir artifacts --pattern 'test-results-*'
WF_NAME=regression-tests WF_CONCLUSION=success python3 scripts/ci/slack_test_summary.py artifacts
```

Verified against three cases: the full artifact set above (9 blocks), no artifacts at all (build-only workflows collapse to header + footer), and a missing junit file (falls back to the old ctest-text regex).

This adds an `actions/checkout` step to the notifier, which it did not previously need. `workflow_run` always resolves the workflow against the default branch, so that is always master's copy of the script, never a PR's.

## 2. Coverage has never been instrumented

`src/CMakeLists.txt` set `CMAKE_CXX_FLAGS` for `ENABLE_COVERAGE` at line 1055, but every `ADD_SUBDIRECTORY` call is at lines 631–645. CMake captures directory-scoped variables when the subdirectory is added, so the flags applied to no target — while `-- Code coverage instrumentation enabled` still printed, which is what made it look healthy.

The full chain: no `-fprofile-instr-generate` anywhere in the 39k-line build log → zero `.profraw` → `coverage.sh` exits 1 with `error: no .profraw files produced` → `continue-on-error: true` swallows it and the step reports **success** → upload finds nothing, warns, uploads no artifact → green `mac-coverage` job, empty report, every night.

### What changed

- Moved the coverage block above the `ADD_SUBDIRECTORY` calls. `ENABLE_GCOV_DATA_FILES` had the identical bug and moves with it. Straight move, no logic change, inert unless one of the options is `ON` — so no normal build is affected.
- `if-no-files-found: error` on the coverage upload, so this cannot fail silently again.

## Testing / what to watch

The Slack script is tested locally as described. The workflow wiring itself cannot be tested before merge (see above).

**The coverage half is not verified by a build.** The argument is structural (CMake scoping) plus the empirical zero-`.profraw`; I have not run an instrumented build. The check is the first nightly `regression-tests` after this merges: `mac-coverage` should produce a `coverage-report-macOS` artifact containing `summary.txt`. If instrumenting every target pushes that job's runtime up a lot, that is worth a follow-up — an instrumented Debug build of the whole tree is not cheap.

Related: #2664 (where the nightly artifact digging started).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
