### PR TITLE
Stop GUI teardown paths segfaulting during static destruction (#2686)

### DIFF
--- a/src/Interface/Application/GuiCommands.cc
+++ b/src/Interface/Application/GuiCommands.cc
@@ -110,7 +110,14 @@ bool QuitCommandGui::execute()
   if (get(RunningPython).toBool())
     SCIRunMainWindow::Instance()->skipSaveCheck();
   SCIRunMainWindow::Instance()->quit();
-  exit(0);
+  // quit() posts a DeferredDelete for the main window and asks the event loop to
+  // unwind, but libc exit() runs static destructors before the loop gets a turn,
+  // so Qt flushes that delete from inside __cxa_finalize -- after the
+  // Core_Application statics are gone. ~SCIRunMainWindow then calls
+  // Application::shutdown() on a half-destroyed singleton and segfaults. Same
+  // mechanism as #2560, fixed here the same way. Settings are already written
+  // synchronously by quit()'s closeEvent.
+  quickExit(0);
   return true;
 }
 

--- a/src/Interface/Application/SCIRunMainWindowCommandInterface.cc
+++ b/src/Interface/Application/SCIRunMainWindowCommandInterface.cc
@@ -32,6 +32,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <Core/Utils/Legacy/MemoryUtil.h>
 #include <Core/Algorithms/Base/AlgorithmVariableNames.h>
+#include <Core/Utils/QuickExit.h>
 #include <Interface/Application/GuiLogger.h>
 #include <Interface/Application/SCIRunMainWindow.h>
 #include <Interface/Application/NetworkEditor.h>
@@ -137,8 +138,10 @@ bool SCIRunMainWindow::loadNetworkFile(const QString& filename, bool isTemporary
     }
     else
     {
+      // quickExit, not exit: the GUI is still up, and libc exit() lets Qt flush
+      // posted deletes during static destruction. See #2686.
       if (Application::Instance().parameters()->isRegressionMode())
-        exit(7);
+        Core::quickExit(7);
       //TODO: set error code to non-0 so regression tests fail!
       // probably want to control this with a --regression flag.
     }


### PR DESCRIPTION
Closes #2686.

Quitting a GUI session segfaults on macOS 15.7.4 with Qt 6.10.2. This is #2560 reached through a second door — that fix routed `--version` away from the GUI path, but left the `exit(0)` that made the path unsafe.

## The mechanism

```cpp
SCIRunMainWindow::Instance()->quit();   // close() posts DeferredDelete, qApp->exit(0)
exit(0);                                 // libc exit -- the loop never gets a turn
```

`close()` posts a `DeferredDelete` for the main window and `qApp->exit(0)` asks the event loop to unwind, but the next statement is libc `exit(0)`. Qt therefore flushes that delete from inside `__cxa_finalize_ranges`, once the `Core_Application` and `Core_Logging` statics have begun tearing down. `~SCIRunMainWindow` calls `Application::shutdown()`, which dispatches through already-destroyed state:

```
0  SCIRun::Core::Application::shutdown() + 96        <- SIGSEGV at 0x10
1  SCIRun::Gui::SCIRunMainWindow::~SCIRunMainWindow() + 240
3  QObject::event(QEvent*) + 724                      <- DeferredDelete
10 QCoreApplicationPrivate::sendPostedEvents + 524
13 __cxa_finalize_ranges + 480
14 exit + 44
15 non-virtual thunk to SCIRun::Gui::QuitCommandGui::execute() + 64
```

Faulting on `ldr x8,[x8,#16]; blr x8` with `x8 == 0`.

The `exit(0)` dates to 6762c22a (2016) and was harmless until Qt 6.10 began flushing posted events during finalization. Qt's own position (QTBUG-48709) is that calling libc `exit()` with a `QApplication` alive is unsafe by construction.

## The change

Two one-line swaps to `Core::quickExit`, the helper #2560 introduced for exactly this (`_Exit` on Apple, `quick_exit` elsewhere), which skips static destructors so Qt never gets the chance:

| site | context |
|---|---|
| `GuiCommands.cc:113` | the crash above |
| `SCIRunMainWindowCommandInterface.cc:141` | regression-mode toolkit-load bailout, found by sweeping — fires with the window still up, and was already inconsistent with `exitApplication`, which takes `quickExit` on its regression branch |

Nothing is lost by skipping static destructors: `writeSettings()` runs synchronously in the `closeEvent` that `quit()` triggers, before either exit. Both call sites were already `[[noreturn]]`, so control flow is unchanged.

The remaining four `exit()` calls live in `Core/ConsoleApplication/ConsoleCommands.cc` and are left alone — no widgets there, so no `DeferredDelete` for finalization to trip over. Line 257 is noted in the issue as worth a separate look, since it exits from an execution-finished callback that may not be on the main thread.

## Testing

Not runtime-tested — I could not build the full application in this environment. Both files pass a syntax check against this repo's real build flags (Qt 6.10.2, `-Wall`). The reasoning rests on the crash report in #2686 plus the documented precedent in #2560, which carries a standalone ~40-line reproducer.

Worth having someone confirm a clean quit on a build before merging, ideally also on Windows and Linux, where the `quick_exit` branch is taken rather than `_Exit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)