### PR TITLE
Stamp version from the last release tag, not the rolling nightly tag

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,11 +72,17 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMake/Modules ${CMAKE_MODULE_P
 
 # Make a version file containing the current version from git.
 include(GetGitRevisionDescription)
-git_describe(VERSION_TAG --tag)
+# Match only release tags (v*). CI moves a rolling `nightly` tag
+# (.github/workflows/publish-release.yml), which would otherwise win here and
+# make the GUI, splash screen and CPack version report "nightly" instead of the
+# last release.
+git_describe(VERSION_TAG --tags --match "v*")
 git_describe(VERSION_BRANCH --all)
 get_git_head_revision(VERSION_REFSPEC VERSION_HASHVAR)
 
-IF(VERSION_TAG MATCHES "HEAD-HASH-NOTFOUND")
+# Covers both no-git (source zip: "HEAD-HASH-NOTFOUND") and a shallow clone with
+# no release tag reachable ("-128-NOTFOUND").
+IF(VERSION_TAG MATCHES "NOTFOUND")
   FILE(READ ${CMAKE_CURRENT_SOURCE_DIR}/LATEST_TAG.txt VERSION_TAG)
   STRING(STRIP ${VERSION_TAG} VERSION_TAG)
   MESSAGE(STATUS "Found tag file for version info: " "${VERSION_TAG}")


### PR DESCRIPTION
## Problem

`src/CMakeLists.txt` derived `VERSION_TAG` with `git describe --tag`, which picks the nearest reachable tag of *any* kind. Since #2588 landed, `.github/workflows/publish-release.yml` moves a rolling `nightly` tag onto master on every nightly run — so that is now always the nearest tag, and it wins.

`VERSION_TAG` feeds `VersionInfo::GIT_VERSION_TAG` through `Version.cc.in`, which is the single source for:

- the main window version button — `src/Interface/Application/SCIRunMainWindowSetup.cc:564`
- the splash screen version line — `src/Interface/Application/GuiCommands.cc:142`
- the ViewScene info dialog — `src/Interface/Modules/Render/ViewScene.cc:3222`
- `--version` — `src/Core/Application/Application.cc:298`

All of them were reporting `nightly-46-g242d8dd9f`.

The version-parsing regexes immediately below expect a leading `v`, so they matched nothing and passed the whole string through unchanged. `SCIRUN_VERSION_STRING` and the CPack package name/version were getting stamped with the nightly string too.

## Fix

Restrict describe to release tags: `--tags --match "v*"`.

Verified against the repo at 242d8dd9f:

| | before | after |
|---|---|---|
| `VERSION_TAG` | `nightly-46-g242d8dd9f` | `v5.0-beta.2026-393-g242d8dd9f` |
| MAJOR / MINOR / PATCH | `nightly-46-g242d8dd9f` (all three) | `5` / `0` / `beta.2026` |

`git_describe(VERSION_BRANCH --all)` is untouched — it resolves to the branch ref, not the tag, and is only used in a status message.

## Also in this PR

The `LATEST_TAG.txt` fallback condition is broadened from `MATCHES "HEAD-HASH-NOTFOUND"` to `MATCHES "NOTFOUND"`. Narrowing to `v*` makes a describe failure somewhat more likely — a shallow clone with no release tag reachable returns `-128-NOTFOUND`, which the old condition did not catch. `reusable-build.yml` uses `fetch-depth: 0`, so this is not hit in CI today; it is the correct behavior if it ever is. Happy to split this out if you'd rather keep the PR to one line.

## Testing

The describe + version-parsing logic was exercised in isolation against the real `.git`, before and after, producing the table above. No full Superbuild configure was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)