### PR TITLE
Stop headless execute segfaulting on a future the queue manager never returns (#2688)

### DIFF
--- a/src/Core/ConsoleApplication/ConsoleCommands.cc
+++ b/src/Core/ConsoleApplication/ConsoleCommands.cc
@@ -26,7 +26,10 @@
 */
 
 
+#include <atomic>
 #include <cstdlib>
+#include <future>
+#include <memory>
 #include <Core/ConsoleApplication/ConsoleCommands.h>
 #include <Core/Utils/QuickExit.h>
 #include <Core/Algorithms/Base/AlgorithmVariableNames.h>
@@ -146,14 +149,68 @@ bool SaveFileCommandConsole::execute()
   return !saveImpl(get(Variables::Filename).toFilename().string()).empty();
 }
 
+namespace
+{
+  /// Blocks until a network execution finishes, however the execution manager
+  /// chooses to report it: ExecutionQueueManager signals completion and returns
+  /// no future at all, so waiting on the future alone dereferences null (#2688).
+  /// Construct before starting execution -- the slot has to be armed first.
+  class ExecutionCompletionWaiter
+  {
+  public:
+    explicit ExecutionCompletionWaiter(SCIRun::Dataflow::Engine::NetworkEditorController& controller)
+      : future_(finished_->get_future())
+    {
+      auto finished = finished_;
+      auto alreadyFinished = alreadyFinished_;
+      connection_ = controller.connectStaticNetworkExecutionFinished(
+        [finished, alreadyFinished](int code)
+        {
+          LOG_CONSOLE("Execution finished with code " << code);
+          // The signal can fire more than once; a second set_value would throw.
+          if (!alreadyFinished->exchange(true))
+            finished->set_value(code);
+        });
+    }
+
+    ~ExecutionCompletionWaiter() { connection_.disconnect(); }
+
+    ExecutionCompletionWaiter(const ExecutionCompletionWaiter&) = delete;
+    ExecutionCompletionWaiter& operator=(const ExecutionCompletionWaiter&) = delete;
+
+    void wait(std::future<int>& executionResult)
+    {
+      if (executionResult.valid())
+        executionResult.wait();
+      else
+        future_.wait();
+    }
+
+  private:
+    // Shared with the slot, which may outlive this object if the signal fires
+    // while it is being destroyed.
+    std::shared_ptr<std::promise<int>> finished_{std::make_shared<std::promise<int>>()};
+    std::shared_ptr<std::atomic<bool>> alreadyFinished_{std::make_shared<std::atomic<bool>>(false)};
+    std::future<int> future_;
+    boost::signals2::connection connection_;
+  };
+}
+
 bool ExecuteCurrentNetworkCommandConsole::execute()
 {
   LOG_CONSOLE("Executing network...");
-  Application::Instance().controller()->connectStaticNetworkExecutionFinished([](int code){ LOG_CONSOLE("Execution finished with code " << code); });
-  Application::Instance().controller()->stopExecutionContextLoopWhenExecutionFinishes();
-  auto val = Application::Instance().controller()->executeAll();
-  LOG_CONSOLE("Execution started.");
-  val.wait();
+  auto& controller = *Application::Instance().controller();
+
+  {
+    // Scoped so the slot is disconnected before interactive mode, which can
+    // start executions of its own.
+    ExecutionCompletionWaiter waiter(controller);
+    controller.stopExecutionContextLoopWhenExecutionFinishes();
+    auto result = controller.executeAll();
+    LOG_CONSOLE("Execution started.");
+    waiter.wait(result);
+  }
+
   LOG_CONSOLE("Execute thread stopped. Entering interactive mode.");
 
   InteractiveModeCommandConsole interactive;

--- a/src/Modules/Basic/CompositeModuleWithStaticPorts.cc
+++ b/src/Modules/Basic/CompositeModuleWithStaticPorts.cc
@@ -94,6 +94,12 @@ void CompositeModuleWithStaticPorts::execute()
     }
 
     auto resultFuture = impl_->subNet_->executeAll();
+    // Some execution managers signal completion instead of returning a future (#2688).
+    if (!resultFuture.valid())
+    {
+      error("Subnetwork execution did not start: no result from the execution manager.");
+      return;
+    }
     resultFuture.wait();
     const auto result = resultFuture.get();
     if (result != 0)

--- a/src/Modules/Basic/CompositeModuleWithTypedStaticPorts.cc
+++ b/src/Modules/Basic/CompositeModuleWithTypedStaticPorts.cc
@@ -90,6 +90,12 @@ void CompositeModuleWithTypedStaticPorts::execute()
     }
 
     auto resultFuture = impl_->subNet_->executeAll();
+    // Some execution managers signal completion instead of returning a future (#2688).
+    if (!resultFuture.valid())
+    {
+      error("Subnetwork execution did not start: no result from the execution manager.");
+      return;
+    }
     resultFuture.wait();
     const auto result = resultFuture.get();
     if (result != 0)


### PR DESCRIPTION
Closes #2688.

Running a GUI-capable build with `-x`/`--headless` and a network to execute segfaults immediately, before any module runs. Deterministic — three-for-three in the crash reports, each process dead in under half a second.

```
0  pthread_mutex_lock                                <- SIGSEGV
1  std::__1::mutex::lock()
2  std::__1::__assoc_sub_state::wait()
3  ExecuteCurrentNetworkCommandConsole::execute()     <- ConsoleCommands.cc:156
5  CommandQueue::runAll()
7  Console::ConsoleApplication::run()
```

## Cause

The command set is chosen at **runtime**, the execution manager at **build time**:

```cpp
// scirunMain.cc:67
if (parameters()->disableGui() || ...) return ConsoleApplication::run(argc, argv);   // ConsoleCommandFactory

// NetworkEditorController.cc:74
#ifndef BUILD_HEADLESS
  collabs_.executionManager_.reset(new ExecutionQueueManager);
#else
  collabs_.executionManager_.reset(new SimpleExecutionManager);
#endif
```

So a GUI-capable binary run headless pairs console commands with `ExecutionQueueManager` — a combination no other configuration produces, and one nothing exercises.

`ExecutionQueueManager::execute` returns a default-constructed `std::future<int>` **by design**: it enqueues to its own launch thread and reports completion through the execution-finished signal. `ExecuteCurrentNetworkCommandConsole` called `wait()` on it regardless. libc++ implements that as `__state_->wait()` → `unique_lock(__mut_)` → `pthread_mutex_lock` on a small offset off null.

| build | run | manager | command | result |
|---|---|---|---|---|
| `BUILD_HEADLESS=ON` | any | Simple | console | fine |
| GUI | with GUI | Queue | `...CommandGui` | fine, never touches the future |
| GUI | `-x` + execute | Queue | `...CommandConsole` | **crashes every time** |

The regression suite runs the GUI path, which is why this has not surfaced there.

## The change

Wait on the completion signal when there is no future to wait on. The command already connected a slot to log the exit code; that slot now also fulfils a `std::promise`, guarded against the signal firing twice, and the `boost::signals2::connection` is dropped once the wait is over so the slot cannot outlive the frame it captures. The `SimpleExecutionManager` path is unchanged — a valid future is still awaited directly.

Also adds a `valid()` guard to the two live composite modules, which call `wait()` then `get()` unguarded and can meet the same invalid future whenever `ExecutionManagerBase::executeImpl` bails out on a missing executor.

## What I deliberately did not do

**Choose the manager from `disableGui()`.** That was the obvious root fix and it does not work: `Core_Application` links `Engine_Network`, so `NetworkEditorController` reading `Application::Instance().parameters()` would be circular. It would also quietly convert `-x` from queued to synchronous execution — a behaviour change, not a bug fix.

**Touch `CompositeModuleTestGFB_FM.cc`.** It has the identical unguarded `wait()`/`get()`, but it is commented out of `src/Modules/Legacy/Fields/CMakeLists.txt:221` and no longer compiles at all (`inputPort->id()` on lines 138 and 153 does not exist on the current port interfaces). I patched it, then reverted: an edit that cannot be compiled or verified is noise. Noted in the issue for whoever revives it.

**Give `ExecutionQueueManager` a real future.** Backing it with a promise fulfilled on completion would make every caller uniform and render both guards unnecessary. That is the right end state, but it is a scheduler change and belongs on its own.

## Testing

All three changed files pass a syntax check against this repo's real build flags. **Not run** — I could not build the full application in this environment.

The direct check is `SCIRun_test -x -e <network>.srn5` on a non-headless build, which segfaults instantly before this change and should now execute and drop into interactive mode.

One thing worth a reviewer's eye: if execution never signals completion, this now blocks where it previously crashed. `BUILD_HEADLESS=ON` builds already have that property on the `val.wait()` path, so it is not new behaviour — but a hang costs a CI job its full timeout where a segfault fails fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)