### PR TITLE
CI: fix empty nightly release; recurse for installers (#2398)

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*'
     paths-ignore:
       - 'docs/**'
   schedule:
@@ -93,6 +95,29 @@ jobs:
       variant: gui
       with-ospray: true
       artifact-name: SCIRunMacOsprayInstaller
+
+  # ---------------------------------------------------------------------------
+  # Publish installers to a GitHub Release (issue #2398). Nightly on cron/master
+  # push; a draft versioned release on a v* tag. Windows publishes to the same
+  # releases from windows.yml. mac-gui-ospray is if:false, so it is not a dep.
+  # ---------------------------------------------------------------------------
+  publish-nightly:
+    needs: [mac-gui, mac-gui-26, mac-gui-26-intel, mac-gui-nonpython]
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/master') }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-release.yml
+    with:
+      channel: nightly
+
+  publish-stable:
+    needs: [mac-gui, mac-gui-26, mac-gui-26-intel, mac-gui-nonpython]
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-release.yml
+    with:
+      channel: stable
 
   # ---------------------------------------------------------------------------
   # Headless builds (with testing enabled)

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,8 +47,10 @@ jobs:
           cd dist
           for d in */; do
             name="${d%/}"
-            # Each subdir holds exactly one installer file.
-            f=$(find "$d" -maxdepth 1 -type f \
+            # Each artifact preserves its build path (bin/SCIRun/... for the
+            # installer, build/** for the .msi), so recurse -- do not restrict
+            # to the top level or the file is missed and then deleted below.
+            f=$(find "$d" -type f \
                   \( -name '*.exe' -o -name '*.pkg' -o -name '*.msi' \) | head -n1)
             [ -n "$f" ] || { echo "No installer in $d, skipping"; continue; }
             ext="${f##*.}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,87 @@
+name: Publish release assets
+
+# Reusable publisher. Called by windows.yml / mac.yml after their build matrix
+# finishes. Downloads this run's installer artifacts and attaches them to a
+# GitHub Release so the binaries live somewhere permanent instead of expiring
+# with the 90-day run-artifact retention (see issue #2398).
+#
+#   channel: nightly  -> rolling prerelease on the `nightly` tag, overwritten
+#                        each run. Asset names drop the version string so they
+#                        replace in place instead of accumulating.
+#   channel: stable   -> draft release on the pushed v* tag, with the tag baked
+#                        into each asset name. Review, then publish by hand.
+#
+# Both windows.yml and mac.yml publish to the SAME release; assets are named per
+# artifact so the platforms coexist rather than clobbering each other.
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        required: true
+        type: string        # 'nightly' or 'stable'
+
+permissions:
+  contents: write           # create/update releases and move the nightly tag
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      # No merge-multiple: every GUI job emits an identically-named installer
+      # (SCIRun-<ver>-win64.exe / SCIRun-<ver>-Darwin.pkg), so flattening would
+      # clobber. Land each artifact in its own dist/<artifact-name>/ subdir.
+      - name: Download installer artifacts from this run
+        uses: actions/download-artifact@v6
+        with:
+          pattern: "*Installer*"
+          path: dist
+
+      - name: Rename to unique, channel-appropriate asset names
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -eu
+          shopt -s nullglob
+          cd dist
+          for d in */; do
+            name="${d%/}"
+            # Each subdir holds exactly one installer file.
+            f=$(find "$d" -maxdepth 1 -type f \
+                  \( -name '*.exe' -o -name '*.pkg' -o -name '*.msi' \) | head -n1)
+            [ -n "$f" ] || { echo "No installer in $d, skipping"; continue; }
+            ext="${f##*.}"
+            if [ "$CHANNEL" = "stable" ]; then
+              out="${name}-${TAG}.${ext}"      # e.g. SCIRunWindowsInstaller_qt6-v5.5.0.exe
+            else
+              out="${name}.${ext}"             # e.g. SCIRunWindowsInstaller_qt6.exe (stable name)
+            fi
+            mv "$f" "$out"
+          done
+          # Drop the now-empty per-artifact subdirs so files: matches only installers.
+          find . -mindepth 1 -type d -exec rm -rf {} + 2>/dev/null || true
+          echo "Assets to publish:"
+          ls -la
+
+      - name: Publish nightly (rolling prerelease)
+        if: ${{ inputs.channel == 'nightly' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: nightly
+          name: Nightly build
+          prerelease: true
+          body: >-
+            Automated nightly build. Assets are overwritten on every run;
+            the tag tracks the latest master commit that produced them.
+          files: dist/*
+
+      - name: Publish stable (draft release on tag)
+        if: ${{ inputs.channel == 'stable' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: SCIRun ${{ github.ref_name }}
+          draft: true                    # review before it goes public
+          generate_release_notes: true
+          files: dist/*

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*'
     paths-ignore:
       - 'docs/**'
   schedule:
@@ -61,3 +63,26 @@ jobs:
       variant: gui
       build-with-python: true
       artifact-name: SCIRunWindowsPythonInstaller_qt6
+
+  # ---------------------------------------------------------------------------
+  # Publish installers to a GitHub Release (issue #2398). Nightly on cron/master
+  # push; a draft versioned release on a v* tag. Mac publishes to the same
+  # releases from mac.yml.
+  # ---------------------------------------------------------------------------
+  publish-nightly:
+    needs: [windows-gui-qt5, windows-gui-qt6, windows-gui-python-qt5, windows-gui-python-qt6]
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/master') }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-release.yml
+    with:
+      channel: nightly
+
+  publish-stable:
+    needs: [windows-gui-qt5, windows-gui-qt6, windows-gui-python-qt5, windows-gui-python-qt6]
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-release.yml
+    with:
+      channel: stable


### PR DESCRIPTION
## Problem

The `nightly` GitHub Release (added in #2588) exists but has **zero assets**. The publish job goes green while attaching nothing, so there's still no durable copy of the installers.

## Root cause

Each build artifact preserves its original build path inside it — the installer lands at `dist/<artifact>/bin/SCIRun/SCIRun-*.pkg` (and the `.msi` under `build/**`). The rename step in `publish-release.yml` searched with `find -maxdepth 1`, one level too shallow, so it found no installer, printed `No installer in .../ skipping`, then the cleanup line deleted the subdirs — **taking the real installers with them**. `files: dist/*` then matched nothing, but `softprops/action-gh-release` still exits 0.

From the mac nightly run log:
```
Starting download of artifact to: .../dist/SCIRunMacInstaller
No installer in SCIRunMacInstaller/, skipping
🤔 Pattern 'dist/*' does not match any files.
```

## Fix

Drop `-maxdepth 1` so `find` recurses into the artifact tree. Verified locally against the real nesting — the rename yields unique flat names:

```
SCIRunMacInstaller.pkg
SCIRunMacInstaller-26.pkg
SCIRunWindowsInstaller_qt6.exe
```

## Note (separate issue)

The **Windows matrix is currently failing** on unrelated `vs2026` build breakage, so it produces no installers regardless. This PR only fixes the mac side reaching the release; Windows won't populate until that build failure is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
