### PR TITLE
CI: unblock the VS 2026 nightly (Qt stdext, CPython UWP coroutine)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -97,6 +97,10 @@ jobs:
   # Nightly-only, not the PR tier (pr.yml), so a VS-2026 break can't block pull
   # requests (#2449). allow-failure until the externals catch up: Boost 1.90's
   # b2 can't bootstrap under VS 2026 (#2657), fixed by the 1.91 upgrade (#2548).
+  #
+  # Qt here is 6.10.2, not the '6.3.*' floor the windows-2022 jobs pin: Qt 6.3's
+  # QVarLengthArray calls stdext::make_checked_array_iterator, which the v145 STL
+  # no longer ships. This job exists to exercise the compiler, not the Qt floor.
   # ---------------------------------------------------------------------------
   windows-2025-headless-vs2026:
     uses: ./.github/workflows/reusable-build.yml
@@ -112,7 +116,7 @@ jobs:
     with:
       runner: windows-2025
       cmake-generator: 'Visual Studio 18 2026'
-      qt-version: '6.3.*'
+      qt-version: '6.10.2'
       variant: gui
       build-with-python: false
       artifact-name: SCIRunWindowsInstaller_qt6_vs2026

--- a/Superbuild/PythonExternal.cmake
+++ b/Superbuild/PythonExternal.cmake
@@ -113,6 +113,12 @@ ELSE()
     # PlatformToolset when unset, so pass it through the environment instead.
     SET(python_MSBUILD_TOOLSET_ENV "PlatformToolset=${CMAKE_VS_PLATFORM_TOOLSET}")
   ENDIF()
+
+  # PC/python_uwp.cpp pulls <experimental/coroutine> through C++/WinRT, which is
+  # a hard error (STL1011) in the v145 STL. Nothing selects projects out of
+  # pcbuild.sln, and SCIRun ships none of the UWP launchers, so take the escape
+  # hatch the assert names. cl.exe reads options out of CL.
+  SET(python_MSVC_ENV "CL=/D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS")
 ENDIF()
 
 # CPython's install: runs frameworkinstallmaclib (symlinks into $(LIBPL)) as a
@@ -163,9 +169,9 @@ ELSE()
     # through cmd, which reads the "/" in "PCbuild/build.bat" as a switch and
     # fails with "'PCbuild' is not recognized as an internal or external command".
     # build.bat forwards any argument it doesn't recognize straight to MSBuild.
-    CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env "NUGET_URL=https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" ${python_MSBUILD_TOOLSET_ENV} "PCbuild\\build.bat"
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env "NUGET_URL=https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" ${python_MSBUILD_TOOLSET_ENV} ${python_MSVC_ENV} "PCbuild\\build.bat"
     BUILD_IN_SOURCE ON
-    BUILD_COMMAND ${CMAKE_BUILD_TOOL} PCbuild/pcbuild.sln /nologo /property:Configuration=Release /property:Platform=${python_WIN32_ARCH} ${python_MSBUILD_TOOLSET}
+    BUILD_COMMAND ${CMAKE_COMMAND} -E env ${python_MSVC_ENV} ${CMAKE_BUILD_TOOL} PCbuild/pcbuild.sln /nologo /property:Configuration=Release /property:Platform=${python_WIN32_ARCH} ${python_MSBUILD_TOOLSET}
     INSTALL_COMMAND "${CMAKE_COMMAND}" -E
       copy_if_different
       <SOURCE_DIR>/PCbuild/${python_WIN32_64BIT_DIR}/pyconfig.h
@@ -173,7 +179,7 @@ ELSE()
   )
   # build both Release and Debug versions
   ExternalProject_Add_Step(Python_external debug_build
-    COMMAND ${CMAKE_BUILD_TOOL} PCbuild/pcbuild.sln /nologo /property:Configuration=Debug /property:Platform=${python_WIN32_ARCH} ${python_MSBUILD_TOOLSET}
+    COMMAND ${CMAKE_COMMAND} -E env ${python_MSVC_ENV} ${CMAKE_BUILD_TOOL} PCbuild/pcbuild.sln /nologo /property:Configuration=Debug /property:Platform=${python_WIN32_ARCH} ${python_MSBUILD_TOOLSET}
       DEPENDEES build
       DEPENDERS install
       WORKING_DIRECTORY <SOURCE_DIR>


### PR DESCRIPTION
Both remaining `windows-2025-*-vs2026` failures in [run 31687060859](https://github.com/SCIInstitute/SCIRun/actions/runs/31687060859) are upstream headers meeting a toolchain that dropped deprecated extensions — neither is SCIRun code. Boost/b2, Cleaver2, Freetype, Glew, Tetgen, Teem all build clean under v145 now, so these two are what's left.

## The GUI job's "Qwt" error is a Qt error

```
D:\a\SCIRun\Qt\6.3.2\msvc2019_64\include\QtCore\qvarlengtharray.h(369,19):
  error C3861: 'stdext': identifier not found
  (compiling source file '_deps/qwt_upstream-src/src/qwt_symbol.cpp')
```

Qt 6.3.2's `qvarlengtharray.h` calls `QT_MAKE_CHECKED_ARRAY_ITERATOR`, defined on MSVC in `qcompilerdetection.h:107` as `stdext::make_checked_array_iterator`. MSVC 14.51 removed `stdext`, so this fires in every Qwt TU that instantiates `QVarLengthArray::operator=(initializer_list)` or `erase()`. Qwt's own source is fine — it's just the first thing in the build that includes QtCore.

The job had inherited `qt-version: '6.3.*'` from the windows-2022 matrix, where that pin is deliberate (it's our Qt6 floor). This job exists to exercise the compiler, not the Qt floor, so it moves to 6.10.2 like the other current-Qt jobs. Qt still has one such call in `QVarLengthArray::erase` as of 6.10 and dev; nothing in the Qwt build instantiates it.

## Headless is stuck on CPython's UWP launchers

```
...MSVC\14.51.36231\include\experimental\coroutine(37,1): error C2338:
  error STL1011: ... <experimental/coroutine> ... deprecated ... REMOVED SOON.
  (compiling source file '../PC/python_uwp.cpp')  [python_uwp.vcxproj]
```

`pythoncore`, `python`, `pythonw` and `pywlauncher` all build; only `python_uwp`/`pythonw_uwp` fail, on a header C++/WinRT drags in. Nothing selects projects out of `pcbuild.sln` and SCIRun ships none of the UWP launchers, so this takes the escape hatch the static_assert names, passed via `CL` on all three msbuild entry points (build.bat, Release, Debug).

## Testing

Both jobs are `allow-failure: true` and nightly-only, so this can't regress the PR tier. Verifying needs a `workflow_dispatch` of windows-build on this branch (the cron only runs on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)