### PR TITLE
CI: publish nightly mac installers to a rolling prerelease

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -168,3 +168,112 @@ jobs:
       variant: headless
       build-testing: true
       run-smoke-test: true
+
+  # ---------------------------------------------------------------------------
+  # Rolling nightly prerelease
+  # ---------------------------------------------------------------------------
+  # Republishes the night's .pkg installers under a single `nightly` tag that is
+  # rewritten in place, so https://github.com/.../releases/tag/nightly is a
+  # permanent link. Actions artifacts expire after 90 days and need a signed-in
+  # GitHub account to download; release assets have neither limit.
+  #
+  # Schedule only -- master pushes would rewrite the release several times a day.
+  nightly-release:
+    # always(): a failed variant should not suppress the ones that worked. The
+    # release body lists what actually made it in.
+    if: ${{ always() && github.event_name == 'schedule' }}
+    needs: [mac-gui, mac-gui-26, mac-gui-26-intel, mac-gui-nonpython]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create/update the release and move the tag
+      actions: read     # download this run's artifacts
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      TAG: nightly
+    steps:
+      - name: Download installer artifacts
+        run: |
+          gh run download "$GITHUB_RUN_ID" --dir artifacts --pattern 'SCIRunMac*' || true
+          ls -R artifacts 2>/dev/null || echo "(none)"
+
+      - name: Name the packages per variant
+        run: |
+          set -eu
+          shopt -s nullglob
+          mkdir -p upload
+
+          # Every variant's CPack output is SCIRun-<version>-Darwin.pkg
+          # (src/CMakeLists.txt:978) -- identical names would clobber each other
+          # as release assets, so map the artifact name onto a variant suffix.
+          for dir in artifacts/*/; do
+            case "$(basename "$dir")" in
+              SCIRunMacInstaller)          suffix=macos-latest-arm64 ;;
+              SCIRunMacInstaller-26)       suffix=macos26-arm64 ;;
+              SCIRunMacInstaller-26-intel) suffix=macos26-x86_64 ;;
+              SCIRunMacNPInstaller)        suffix=macos-latest-arm64-nopython ;;
+              *) echo "::warning::Unrecognized artifact $(basename "$dir"); skipping"; continue ;;
+            esac
+            for pkg in "$dir"*.pkg; do
+              base="$(basename "$pkg" .pkg)"        # SCIRun-5.0.0-Darwin
+              cp "$pkg" "upload/${base%-Darwin}-${suffix}.pkg"
+            done
+          done
+          ls -l upload
+
+      - name: Publish rolling prerelease
+        run: |
+          set -eu
+          shopt -s nullglob
+          files=(upload/*.pkg)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No macOS installers were produced; leaving the existing nightly release alone."
+            exit 1
+          fi
+
+          {
+            echo "Automated build of \`master\` from $(date -u +%Y-%m-%d). Rewritten nightly --"
+            echo "assets and commit change without notice, and this is not a supported release."
+            echo
+            echo "Built from ${GITHUB_SHA}."
+            echo
+            echo "| Installer | Runner image | Architecture | Python |"
+            echo "| --- | --- | --- | --- |"
+            for f in "${files[@]}"; do
+              case "$f" in
+                *-macos-latest-arm64-nopython.pkg) echo "| \`$(basename "$f")\` | macOS-latest | arm64 | no |" ;;
+                *-macos-latest-arm64.pkg)          echo "| \`$(basename "$f")\` | macOS-latest | arm64 | yes |" ;;
+                *-macos26-arm64.pkg)               echo "| \`$(basename "$f")\` | macOS 26 | arm64 | yes |" ;;
+                *-macos26-x86_64.pkg)              echo "| \`$(basename "$f")\` | macOS 26 | x86_64 | yes |" ;;
+              esac
+            done
+            echo
+            echo "### These packages are not signed or notarized"
+            echo
+            echo "Gatekeeper will refuse to open them on download (see issue #1663). To install anyway:"
+            echo
+            echo '```'
+            echo "xattr -dr com.apple.quarantine <downloaded>.pkg"
+            echo "sudo installer -pkg <downloaded>.pkg -target /"
+            echo '```'
+          } > notes.md
+
+          title="SCIRun nightly (macOS) — $(date -u +%Y-%m-%d)"
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            # A published release ignores target_commitish updates, so the git
+            # ref has to be force-moved for the release to show tonight's commit.
+            gh api -X PATCH "repos/${GH_REPO}/git/refs/tags/${TAG}" \
+              -f sha="$GITHUB_SHA" -F force=true >/dev/null
+            gh release edit "$TAG" --title "$title" --notes-file notes.md --prerelease
+            # Drop last night's assets first: a variant that failed tonight must
+            # not leave a stale installer sitting next to the fresh ones.
+            for asset in $(gh release view "$TAG" --json assets --jq '.assets[].name'); do
+              gh release delete-asset "$TAG" "$asset" --yes
+            done
+            gh release upload "$TAG" "${files[@]}" --clobber
+          else
+            gh release create "$TAG" "${files[@]}" \
+              --prerelease --target "$GITHUB_SHA" \
+              --title "$title" --notes-file notes.md
+          fi

--- a/.github/workflows/nightly-slack.yml
+++ b/.github/workflows/nightly-slack.yml
@@ -72,6 +72,8 @@ jobs:
 
       - name: Build Slack payload
         env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           WF_NAME: ${{ github.event.workflow_run.name }}
           WF_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           WF_URL: ${{ github.event.workflow_run.html_url }}
@@ -109,13 +111,21 @@ jobs:
             emoji=":large_yellow_circle:"
           fi
 
+          # mac-build attaches its installers to the rolling `nightly` prerelease
+          # (see mac.yml). Link it only when the tag actually moved to this run's
+          # commit -- otherwise the nightly-release job failed and the link would
+          # silently point at an older build.
+          install_line=""
+          if [ "$WF_NAME" = "mac-build" ]; then
+            tag_sha="$(gh api "repos/${REPO}/git/ref/tags/nightly" --jq '.object.sha' 2>/dev/null || true)"
+            if [ "$tag_sha" = "$WF_SHA" ]; then
+              install_line="\n:package: <https://github.com/${REPO}/releases/tag/nightly|macOS installers> (.pkg, unsigned)"
+            fi
+          fi
+
           header="${emoji} *${WF_NAME}* nightly — ${WF_CONCLUSION}"
           footer="<${WF_URL}|View run> · \`${short_sha}\` (${WF_BRANCH})"
-          if [ -n "$test_lines" ]; then
-            text="${header}${test_lines}\n${footer}"
-          else
-            text="${header}\n${footer}"
-          fi
+          text="${header}${test_lines}${install_line}\n${footer}"
 
           # Build the JSON with jq so newlines and any special characters in the
           # summary are escaped correctly. printf %b expands the \n separators.


### PR DESCRIPTION
The mac nightly already builds four `.pkg` installers, but they only ever existed as Actions artifacts: 90-day expiry, and a signed-in GitHub account needed to download one. This attaches them to a rolling `nightly` prerelease so there is a permanent, anonymous download link, and posts that link to the same Slack channel as the nightly test results.

## `mac.yml` — new `nightly-release` job

Schedule-only (master pushes would rewrite the release several times a day), `needs` the four installer-producing jobs with `if: always()` so one red variant still publishes the rest.

Three details that aren't obvious from the diff:

- **The packages get renamed.** All four variants emit `SCIRun-<version>-Darwin.pkg` — CPack sets a single `PKG_FILE_NAME` in `src/CMakeLists.txt`. As release assets those identical names would overwrite each other, so each gets a runner/arch/python suffix: `SCIRun-5.0.0-macos26-arm64.pkg`, `-macos26-x86_64.pkg`, `-macos-latest-arm64.pkg`, `-macos-latest-arm64-nopython.pkg`.
- **Updating the release force-moves the git ref.** GitHub ignores `target_commitish` on an already-published release, so without the explicit ref update the release page would keep showing whatever commit the tag was first cut from, forever.
- **Yesterday's assets are deleted before upload,** so a variant that fails tonight doesn't leave a stale installer sitting next to fresh ones.

## `nightly-slack.yml` — installer link

Adds a `:package:` line to the existing `mac-build` message. It only appears when the `nightly` tag's sha matches the run's head sha — if the release job failed, the message omits the link rather than quietly pointing at the previous night's build.

## Testing

`workflow_run` and `schedule` triggers only fire from the default branch, so **none of this can be exercised from a PR branch** — the same caveat already documented at the top of `nightly-slack.yml`. The first real exercise is the first nightly after merge. What I did verify locally: both files parse as YAML, and the rename/notes-table logic was dry-run against a simulated artifact set including a missing variant.

Everything is additive — a new job at the end of `mac.yml` plus one hunk in `nightly-slack.yml` — so it should not conflict with the other CI work in flight (#2575, #2576, #2644).

## Not signed

The packages remain unsigned and un-notarized, so Gatekeeper will refuse them on download. The release body ships the `xattr -dr com.apple.quarantine` workaround as a stopgap and points at #1663, which now carries the full signing process, ordering constraints, and a TODO list. Publishing these behind a public link raises the priority of that issue but doesn't depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
