### PR TITLE
CI: link the nightly installers from Slack, and flag them as unsigned

### DIFF
--- a/.github/workflows/nightly-slack.yml
+++ b/.github/workflows/nightly-slack.yml
@@ -110,6 +110,21 @@ jobs:
             2>/dev/null || true)"
           export WF_FAILED_JOBS
 
+          # mac.yml and windows.yml both publish installers to the shared
+          # `nightly` release (publish-release.yml). Link it only when the tag
+          # actually points at this run's commit: publish-nightly also fires on
+          # master pushes, so an unconditional link would happily advertise a
+          # build from six hours before the one being reported.
+          WF_INSTALLER_URL=""
+          if [ "$WF_NAME" = "mac-build" ] || [ "$WF_NAME" = "windows-build" ]; then
+            tag_sha="$(gh api "repos/${REPO}/git/ref/tags/nightly" \
+              -q '.object.sha' 2>/dev/null || true)"
+            if [ -n "$tag_sha" ] && [ "$tag_sha" = "$WF_SHA" ]; then
+              WF_INSTALLER_URL="https://github.com/${REPO}/releases/tag/nightly"
+            fi
+          fi
+          export WF_INSTALLER_URL
+
           python3 scripts/ci/slack_test_summary.py artifacts > payload.json
           echo "Payload:"
           cat payload.json

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -73,9 +73,19 @@ jobs:
           tag_name: nightly
           name: Nightly build
           prerelease: true
-          body: >-
+          body: |
             Automated nightly build. Assets are overwritten on every run;
             the tag tracks the latest master commit that produced them.
+
+            **These binaries are not signed or notarized** (issue #1663), so
+            both platforms will refuse to launch them straight from a download.
+            On macOS, clear the quarantine flag first:
+
+            ```
+            xattr -dr com.apple.quarantine <downloaded>.pkg
+            ```
+
+            On Windows, SmartScreen needs "More info" → "Run anyway".
           files: dist/*
 
       - name: Publish stable (draft release on tag)

--- a/scripts/ci/slack_test_summary.py
+++ b/scripts/ci/slack_test_summary.py
@@ -131,6 +131,11 @@ def build(reports, env):
     # still green. Set by nightly-slack.yml.
     failed_jobs = env.get("WF_FAILED_JOBS", "").strip()
 
+    # Release URL, set by nightly-slack.yml only when this run's own installers
+    # are the ones on the nightly tag. Empty means publish-nightly did not run
+    # or did not win the tag, so linking would point at someone else's build.
+    installer_url = env.get("WF_INSTALLER_URL", "").strip()
+
     any_failed = any(r.failed for r in reports)
     header = (f"{emoji_for(conclusion, any_failed, failed_jobs)} "
               f"*{name}* nightly — {conclusion}")
@@ -146,6 +151,16 @@ def build(reports, env):
             "type": "context",
             "elements": [{"type": "mrkdwn",
                           "text": f"*failed, non-blocking:* {failed_jobs}"}],
+        })
+
+    # Also above the fields, for the same reason: this is the one line a reader
+    # might actually want to click, so the trim must not be able to reach it.
+    if installer_url:
+        blocks.append({
+            "type": "context",
+            "elements": [{"type": "mrkdwn",
+                          "text": f":package: <{installer_url}|Installers from "
+                                  "this run> — unsigned, see #1663"}],
         })
 
     # One field per report, two columns. Slack caps a section at 10 fields, so


### PR DESCRIPTION
Follow-on to #2398 / #2588. Those put the installers on a rolling `nightly` release; nothing points at it, and nothing warns that the binaries are unsigned.

Replaces #2702, which reimplemented the publisher that already exists — my mistake, closed.

## Link the release from the nightly Slack summary

The nightly summary reports test counts only, so the installers are discoverable only if you already know the tag URL. This adds a line to the `mac-build` and `windows-build` summaries — the two workflows that call `publish-nightly`.

The URL is resolved in `nightly-slack.yml` and passed in as `WF_INSTALLER_URL`, matching how `WF_FAILED_JOBS` is already handled, so `slack_test_summary.py` stays runnable offline.

**It only links when the nightly tag's sha matches the reported run's head sha.** `publish-nightly` fires on master pushes as well as the cron, so an unconditional link would advertise whichever build last moved the tag — on a busy day, not the one the message is about. If the publish didn't happen or lost the race, the line is simply absent.

The block sits above the fields, for the same reason the `failed, non-blocking` block does: the 50-block trim drops from the middle, and this is the one line a reader might actually want to click.

## Say that the packages are unsigned

Nothing in the release body mentioned it, so the first thing a user hits is Gatekeeper or SmartScreen refusing to open a file they were just handed. The body now says so and gives the `xattr -dr com.apple.quarantine` workaround, pointing at #1663 — which now carries the full signing process, the ordering constraints, and a TODO list.

Worth knowing from that writeup, since it affects how long the note stays: signing is not the `productbuild --sign` one-liner it looks like. `repair_package.sh` ends with `pkgutil --expand` + `--flatten`, which strips a package signature, and the `install_name_tool` fixups in `osx_bundle/CMakeLists.txt` invalidate bundle signatures — so both signing steps have to happen in CI, after those. The actual blocker is that the Developer ID cert dates to 2020 and will have expired.

## Testing

`workflow_run` can't be exercised from a branch, but the payload script can, which is the point of the split in #2680:

```
WF_NAME=mac-build WF_CONCLUSION=success \
  WF_INSTALLER_URL=https://github.com/SCIInstitute/SCIRun/releases/tag/nightly \
  python3 scripts/ci/slack_test_summary.py artifacts
```

Verified the block appears with the variable set and is absent without it, that both YAML files parse, and that the tag-matching shell logic selects mac-build/windows-build and skips linux-build against the live `nightly` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
