### PR TITLE
Fix use-after-free in HasPropertyManager lazy init (#2700)

### DIFF
--- a/src/Core/Datatypes/PropertyManagerExtensions.cc
+++ b/src/Core/Datatypes/PropertyManagerExtensions.cc
@@ -26,22 +26,34 @@
 */
 
 
+#include <mutex>
 #include <Core/Datatypes/PropertyManagerExtensions.h>
 #include <Core/Datatypes/Legacy/Base/PropertyManager.h>
 
 using namespace SCIRun;
 using namespace SCIRun::Core::Datatypes;
 
+namespace
+{
+  // One FieldHandle commonly fans out to several modules that execute
+  // concurrently, and each may be the first to touch its properties. Without
+  // this lock both threads construct a PropertyManager, the loser's is freed
+  // while the winner is still reading it, and the process dies in
+  // copy_properties (#2700). A file-static lock keeps HasPropertyManager
+  // trivially copyable-by-value, which MatrixBase relies on.
+  std::mutex propertyManagerInitLock;
+}
+
 PropertyManager& HasPropertyManager::properties()
 {
-  if (!properties_)
-    properties_.reset(new PropertyManager);
-
-  return *properties_;
+  // Same lazy init as the const overload; const_cast rather than duplicate it.
+  return const_cast<PropertyManager&>(const_cast<const HasPropertyManager*>(this)->properties());
 }
 
 const PropertyManager& HasPropertyManager::properties() const
 {
+  std::lock_guard<std::mutex> guard(propertyManagerInitLock);
+
   if (!properties_)
     properties_.reset(new PropertyManager);
 


### PR DESCRIPTION
Fixes part of #2700.

## What's wrong

`HasPropertyManager::properties()` lazy-initializes a `mutable SharedPointer<PropertyManager>` with no synchronization — and the `const` overload does it too:

```cpp
const PropertyManager& HasPropertyManager::properties() const
{
  if (!properties_)
    properties_.reset(new PropertyManager);   // unsynchronized, on a shared object
  return *properties_;
}
```

One `FieldHandle` commonly fans out to several downstream modules, which execute concurrently on the dataflow thread pool. Each calls `CopyProperties(*input, *output)` → `from.properties()` on the *same* input field. Two threads both see null, both `reset(new PropertyManager)`, and the loser's PropertyManager is destroyed while the winner is still iterating its map inside `copy_properties`.

Crash report from a local repro (macOS 15.7.4, arm64):

```
PropertyManager::copy_properties + 208           <- ldr x8, [x25,#0x38], x25 = 0
TransformMeshWithTransformAlgo::run(...)
TransformMeshWithTransform::execute()
DynamicExecutor::ModuleExecutor::run()           <- dataflow worker thread
```

`x25 = 0` is a freed map node while walking `src->properties_` — not a null `src`. Reading freed memory is also why the nightly reports `Bus error` while the local repro gave `Segmentation fault`.

This is not specific to `TransformMeshWithTransform`: ~26 algorithm files call `CopyProperties`, and any of them running concurrently on a shared field can hit it.

## The fix

Guard the initialization with a file-static mutex, and have the non-const overload delegate to the const one so there's a single init path.

It cannot be a member: `MatrixBase` copies `HasPropertyManager` implicitly, and a `mutex` or `once_flag` member would make the class non-copyable. Contention is negligible — `properties()` is called a handful of times per module execution, and the lock is released before the PropertyManager is used. Eager construction in the constructor was the alternative, but it needs an explicit copy constructor or every matrix copy silently shares one PropertyManager with its original.

## Verification

`ExampleNets/regression/Modules/createGeometricTransform.srn5` (one `CreateLatVol` feeding three `TransformMeshWithTransform`), run directly on macOS arm64:

| | crashes |
|---|---|
| before | 1 / 10 |
| after | 0 / 30 |

No new entries in `~/Library/Logs/DiagnosticReports/` after the fix.

## Not covered by this PR

- The `-j3` / "three GUIs render concurrently" theory in #2700 is dead: every ViewScene network already gets `RESOURCE_LOCK gpu` (`src/Testing/CMakeLists.txt:189`), and the nightly log confirms ctest runs them one at a time. The parallelism that matters is inside a single process.
- `scaleBar1` has no fan-out and no `CopyProperties` call, yet still failed in the nightly, so at least one other crash site remains. Uploading `~/Library/Logs/DiagnosticReports/` as a CI artifact on failure — as suggested in #2700 — would find it in one night.

🤖 Generated with [Claude Code](https://claude.com/claude-code)