### PR TITLE
CI: collect macOS crash reports from test runs (#2700)

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -347,6 +347,22 @@ jobs:
           rm -f "$HOME"/.config/"SCI:CIBC Software"/SCIRun5_regression_*.conf 2>/dev/null || true
         continue-on-error: true
 
+      - name: Collect macOS crash reports
+        if: ${{ (inputs.run-unit-tests || inputs.run-regression-tests) && runner.os == 'macOS' }}
+        run: |
+          # A test that dies on a signal reports only "Bus error" through ctest,
+          # which is not enough to act on (#2700). macOS already writes a full
+          # symbolicated .ips per crash; collect them so the nightly turns a
+          # signal into a stack. ReportCrash writes asynchronously, so give the
+          # last crash of the run a moment to land.
+          sleep 10
+          mkdir -p "$GITHUB_WORKSPACE/crash-reports"
+          for d in "$HOME/Library/Logs/DiagnosticReports" /Library/Logs/DiagnosticReports; do
+            [ -d "$d" ] && cp "$d"/SCIRun*.ips "$GITHUB_WORKSPACE/crash-reports/" 2>/dev/null
+          done
+          echo "collected $(ls -1 "$GITHUB_WORKSPACE/crash-reports" 2>/dev/null | wc -l) crash report(s)"
+        continue-on-error: true
+
       - name: Run unit tests (Windows)
         if: ${{ inputs.run-unit-tests && runner.os == 'Windows' }}
         working-directory: bin/SCIRun
@@ -397,6 +413,7 @@ jobs:
             bin/SCIRun/Testing/Temporary/LastTest.log
             junit-unit.xml
             junit-regression.xml
+            crash-reports/
 
       - name: Upload test logs (Windows)
         if: ${{ (inputs.run-unit-tests || inputs.run-regression-tests) && runner.os == 'Windows' }}

--- a/src/Testing/CMakeLists.txt
+++ b/src/Testing/CMakeLists.txt
@@ -177,8 +177,8 @@ IF(RUN_BASIC_REGRESSION_TESTS)
       SET_TESTS_PROPERTIES("${test_name}" PROPERTIES ENVIRONMENT "${SCIRUN_TEST_DLL_ENVIRONMENT}")
     ENDIF()
 
-    # Networks that instantiate a ViewScene render through an offscreen GL
-    # context in regression mode. macOS serializes GPU command submission
+    # Networks that instantiate a ViewScene render through a real windowed GL
+    # context, in regression mode too. macOS serializes GPU command submission
     # across contexts, so running several ViewScene networks concurrently can
     # slow rendering enough to trip the in-app regression timeout. Give these
     # tests a shared RESOURCE_LOCK so CTest never schedules two of them at once,


### PR DESCRIPTION
Diagnostics for #2700. Complements #2705, which fixes one of the two crash clusters.

## Why

A regression test that dies on a signal surfaces through ctest as `Bus error` and nothing else:

```
286/312 Test #333: .Test.ExampleNetwork.scaleBar1_srn ......Bus error***Exception:   3.09 sec
```

No stack, no faulting thread, no way to tell two different crashes apart. macOS already writes a fully symbolicated `.ips` report for every crash — we just throw it away at the end of the job. This collects them after the unit and regression steps and ships them with the existing test-log artifact.

That is what cracked the first cluster: the same `.ips` from a local repro named the faulting frame and the null register immediately. One nightly with this merged should give a stack for each of the ~13 still-unexplained networks.

`ReportCrash` writes asynchronously, hence the settle wait before copying. The step is `continue-on-error` and `if-no-files-found: ignore` already covers the clean-night case.

## Why the second cluster needs CI to answer this

Classifying both nights' failures against the modules that actually touch a `PropertyManager`, only about 5 of 20 are explained by the race fixed in #2705. The rest — `scaleBar1`, `createLatVol_new`, `embbSimple`, `vsBars`, `widgetFeedbackTest` and friends — contain no module that touches one, and `scaleBar1`'s CI output puts the crash 0.28s after `Done waiting`, right after the shader-uniform lines and well short of a normal 4s run. It dies while the first frames render.

I ran 40 local iterations across five of those networks on an M2: zero crashes, zero crash reports. The likely reason is that the GitHub macOS runner renders windowed OpenGL through a VM's paravirtualized graphics while my local runs use a real GPU — same code path, different driver. So the stack has to come from CI.

## Also in this PR

The `RESOURCE_LOCK` comment in `src/Testing/CMakeLists.txt` claims regression mode renders through an offscreen GL context. `OffscreenGLRenderer` has no callers — ViewScene uses the real windowed context in regression runs too. The lock's rationale (GPU contention tripping the in-app timeout) is unchanged, but the stale comment sends anyone investigating #2700 to the wrong renderer, which it did to me.

`OffscreenGLRenderer.{h,cc}` being dead code is left alone here; that is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)