### PR TITLE
Add VMesh::get_all_neighbors for delem inputs (#2434)

### DIFF
--- a/src/Core/Datatypes/Legacy/Field/PointCloudMesh.cc
+++ b/src/Core/Datatypes/Legacy/Field/PointCloudMesh.cc
@@ -65,6 +65,8 @@ public:
                          VMesh::Elem::index_type i) const override;
   void get_elems(VMesh::Elem::array_type& elems,
                          VMesh::Node::index_type i) const override;
+  void get_elems(VMesh::Elem::array_type& elems,
+                         VMesh::DElem::index_type i) const override;
 
   void get_center(Point &point, VMesh::Node::index_type i) const override;
   void get_center(Point &point, VMesh::Elem::index_type i) const override;
@@ -241,6 +243,15 @@ template <class MESH>
 void
 VPointCloudMesh<MESH>::get_elems(VMesh::Elem::array_type& elems,
                                  VMesh::Node::index_type i) const
+{
+  elems.resize(1); elems[0] = static_cast<VMesh::Elem::index_type>(i);
+}
+
+/// Node, elem and delem are all the same thing in a point cloud.
+template <class MESH>
+void
+VPointCloudMesh<MESH>::get_elems(VMesh::Elem::array_type& elems,
+                                 VMesh::DElem::index_type i) const
 {
   elems.resize(1); elems[0] = static_cast<VMesh::Elem::index_type>(i);
 }

--- a/src/Core/Datatypes/Legacy/Field/Tests/CMakeLists.txt
+++ b/src/Core/Datatypes/Legacy/Field/Tests/CMakeLists.txt
@@ -35,6 +35,7 @@ SET(Core_Datatypes_Legacy_Field_Tests_SRCS
   #MeshFactoryTests.cc
   #TriSurfMeshTests.cc
   TetVolMeshTests.cc
+  VMeshNeighborTests.cc
 )
 
 SCIRUN_ADD_UNIT_TEST(Core_Datatypes_Legacy_Field_Tests ${Core_Datatypes_Legacy_Field_Tests_SRCS})

--- a/src/Core/Datatypes/Legacy/Field/Tests/VMeshNeighborTests.cc
+++ b/src/Core/Datatypes/Legacy/Field/Tests/VMeshNeighborTests.cc
@@ -1,0 +1,251 @@
+/*
+   For more information, please see: http://software.sci.utah.edu
+
+   The MIT License
+
+   Copyright (c) 2020 Scientific Computing and Imaging Institute,
+   University of Utah.
+
+   Permission is hereby granted, free of charge, to any person obtaining a
+   copy of this software and associated documentation files (the "Software"),
+   to deal in the Software without restriction, including without limitation
+   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+   and/or sell copies of the Software, and to permit persons to whom the
+   Software is furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+*/
+
+/// Tests for VMesh::get_all_neighbors (issue #2434): every element on a delem,
+/// without having to hand one of them in.
+
+#include <Testing/Utils/SCIRunFieldSamples.h>
+
+#include <Core/Datatypes/Legacy/Field/VMesh.h>
+#include <Core/Datatypes/Legacy/Field/Field.h>
+#include <Core/Datatypes/Legacy/Field/VField.h>
+#include <Core/Datatypes/Legacy/Field/FieldInformation.h>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <set>
+#include <vector>
+
+using namespace SCIRun;
+using namespace SCIRun::Core::Datatypes;
+using namespace SCIRun::Core::Geometry;
+using namespace SCIRun::TestUtils;
+
+namespace
+{
+  std::set<VMesh::index_type> toSet(const VMesh::Elem::array_type& elems)
+  {
+    std::set<VMesh::index_type> s;
+    for (const auto& e : elems) s.insert(e);
+    return s;
+  }
+
+  bool contains(const VMesh::DElem::array_type& delems, VMesh::DElem::index_type d)
+  {
+    return std::find(delems.begin(), delems.end(), d) != delems.end();
+  }
+
+  /// The properties get_all_neighbors has to hold for any mesh type:
+  /// every returned element really touches the delem, no duplicates, and the
+  /// result agrees with what get_neighbor/get_neighbors say once you pick one
+  /// of the elements to stand in as "from".
+  void checkDelemNeighborsAgree(VMesh* mesh)
+  {
+    VMesh::DElem::size_type numDelems;
+    mesh->size(numDelems);
+    ASSERT_GT(numDelems, 0);
+
+    for (VMesh::index_type d = 0; d < numDelems; ++d)
+    {
+      const VMesh::DElem::index_type delem(d);
+
+      VMesh::Elem::array_type all;
+      mesh->get_all_neighbors(all, delem);
+
+      const auto allSet = toSet(all);
+      EXPECT_EQ(allSet.size(), all.size()) << "duplicate elements on delem " << d;
+      EXPECT_FALSE(all.empty()) << "delem " << d << " belongs to no element";
+
+      for (const auto& elem : all)
+      {
+        VMesh::DElem::array_type delems;
+        mesh->get_delems(delems, elem);
+        EXPECT_TRUE(contains(delems, delem))
+          << "elem " << elem << " does not actually touch delem " << d;
+
+        // get_neighbors() is get_all_neighbors() minus the element you asked from.
+        VMesh::Elem::array_type others;
+        const bool hasNeighbor = mesh->get_neighbors(others, elem, delem);
+        auto expected = allSet;
+        expected.erase(elem);
+        EXPECT_EQ(expected, toSet(others));
+        EXPECT_EQ(hasNeighbor, !expected.empty());
+
+        // Same for the single-neighbor call.
+        VMesh::Elem::index_type neighbor;
+        if (mesh->get_neighbor(neighbor, elem, delem))
+          EXPECT_EQ(1u, expected.count(neighbor));
+        else
+          EXPECT_TRUE(expected.empty());
+      }
+    }
+  }
+
+  /// Number of delems shared by exactly n elements.
+  size_t countDelemsWith(VMesh* mesh, size_t n)
+  {
+    VMesh::DElem::size_type numDelems;
+    mesh->size(numDelems);
+
+    size_t count = 0;
+    for (VMesh::index_type d = 0; d < numDelems; ++d)
+    {
+      VMesh::Elem::array_type all;
+      mesh->get_all_neighbors(all, VMesh::DElem::index_type(d));
+      if (all.size() == n) ++count;
+    }
+    return count;
+  }
+}
+
+TEST(VMeshGetAllNeighborsTest, TetVolAgreesWithGetNeighbor)
+{
+  auto field = CubeTetVolLinearBasis(data_info_type::NONE_E);
+  auto mesh = field->vmesh();
+  mesh->synchronize(Mesh::FACES_E | Mesh::DELEMS_E | Mesh::ELEM_NEIGHBORS_E);
+
+  checkDelemNeighborsAgree(mesh);
+}
+
+TEST(VMeshGetAllNeighborsTest, TetVolCubeSplitsIntoBoundaryAndInteriorFaces)
+{
+  auto field = CubeTetVolLinearBasis(data_info_type::NONE_E);
+  auto mesh = field->vmesh();
+  mesh->synchronize(Mesh::FACES_E | Mesh::DELEMS_E | Mesh::ELEM_NEIGHBORS_E);
+
+  // 6 tets, 4 faces each: the 12 cube-surface triangles are used once, the
+  // 6 interior faces twice.
+  VMesh::DElem::size_type numDelems;
+  mesh->size(numDelems);
+  EXPECT_EQ(18, numDelems);
+  EXPECT_EQ(12u, countDelemsWith(mesh, 1));
+  EXPECT_EQ(6u, countDelemsWith(mesh, 2));
+  EXPECT_EQ(0u, countDelemsWith(mesh, 3));
+}
+
+TEST(VMeshGetAllNeighborsTest, TetVolSingleElementHasOnlyBoundaryFaces)
+{
+  auto field = TetrahedronTetVolLinearBasis(data_info_type::NONE_E);
+  auto mesh = field->vmesh();
+  mesh->synchronize(Mesh::FACES_E | Mesh::DELEMS_E | Mesh::ELEM_NEIGHBORS_E);
+
+  VMesh::DElem::size_type numDelems;
+  mesh->size(numDelems);
+  EXPECT_EQ(4, numDelems);
+
+  for (VMesh::index_type d = 0; d < numDelems; ++d)
+  {
+    VMesh::Elem::array_type all;
+    mesh->get_all_neighbors(all, VMesh::DElem::index_type(d));
+    ASSERT_EQ(1u, all.size());
+    EXPECT_EQ(0, all[0]);
+  }
+}
+
+TEST(VMeshGetAllNeighborsTest, TriSurfAgreesWithGetNeighbor)
+{
+  auto field = CubeTriSurfLinearBasis(data_info_type::NONE_E);
+  auto mesh = field->vmesh();
+  mesh->synchronize(Mesh::EDGES_E | Mesh::DELEMS_E | Mesh::ELEM_NEIGHBORS_E);
+
+  checkDelemNeighborsAgree(mesh);
+}
+
+TEST(VMeshGetAllNeighborsTest, TriSurfClosedSurfaceHasNoBoundaryEdges)
+{
+  auto field = CubeTriSurfLinearBasis(data_info_type::NONE_E);
+  auto mesh = field->vmesh();
+  mesh->synchronize(Mesh::EDGES_E | Mesh::DELEMS_E | Mesh::ELEM_NEIGHBORS_E);
+
+  VMesh::DElem::size_type numDelems;
+  mesh->size(numDelems);
+  EXPECT_EQ(countDelemsWith(mesh, 2), static_cast<size_t>(numDelems));
+}
+
+TEST(VMeshGetAllNeighborsTest, TriSurfSingleTriangleIsAllBoundary)
+{
+  auto field = TriangleTriSurfLinearBasis(data_info_type::NONE_E);
+  auto mesh = field->vmesh();
+  mesh->synchronize(Mesh::EDGES_E | Mesh::DELEMS_E | Mesh::ELEM_NEIGHBORS_E);
+
+  checkDelemNeighborsAgree(mesh);
+
+  VMesh::DElem::size_type numDelems;
+  mesh->size(numDelems);
+  EXPECT_EQ(3, numDelems);
+  EXPECT_EQ(3u, countDelemsWith(mesh, 1));
+}
+
+TEST(VMeshGetAllNeighborsTest, LatVolAgreesWithGetNeighbor)
+{
+  auto field = CreateEmptyLatVol(3, 3, 3);
+  auto mesh = field->vmesh();
+  mesh->synchronize(Mesh::FACES_E | Mesh::DELEMS_E | Mesh::ELEM_NEIGHBORS_E);
+
+  checkDelemNeighborsAgree(mesh);
+}
+
+TEST(VMeshGetAllNeighborsTest, LatVolInteriorFacesHaveTwoElements)
+{
+  // 2x2x2 cells: 36 faces, of which 24 are on the outside of the block.
+  auto field = CreateEmptyLatVol(3, 3, 3);
+  auto mesh = field->vmesh();
+  mesh->synchronize(Mesh::FACES_E | Mesh::DELEMS_E | Mesh::ELEM_NEIGHBORS_E);
+
+  VMesh::DElem::size_type numDelems;
+  mesh->size(numDelems);
+  EXPECT_EQ(36, numDelems);
+  EXPECT_EQ(24u, countDelemsWith(mesh, 1));
+  EXPECT_EQ(12u, countDelemsWith(mesh, 2));
+}
+
+TEST(VMeshGetAllNeighborsTest, PointCloudDelemIsItsOwnElement)
+{
+  FieldInformation fi(mesh_info_type::POINTCLOUDMESH_E,
+                      databasis_info_type::CONSTANTDATA_E, data_info_type::DOUBLE_E);
+  auto field = CreateField(fi);
+  auto mesh = field->vmesh();
+  mesh->add_point(Point(0.0, 0.0, 0.0));
+  mesh->add_point(Point(1.0, 0.0, 0.0));
+  mesh->add_point(Point(0.0, 1.0, 0.0));
+
+  // A point cloud reports no delems of its own, but node, elem and delem all
+  // index the same thing, so a delem index is still answerable.
+  VMesh::Elem::size_type numElems;
+  mesh->size(numElems);
+  ASSERT_EQ(3, numElems);
+
+  // Points have no neighbors, but a point is still the one element on its delem.
+  for (VMesh::index_type d = 0; d < numElems; ++d)
+  {
+    VMesh::Elem::array_type all;
+    mesh->get_all_neighbors(all, VMesh::DElem::index_type(d));
+    ASSERT_EQ(1u, all.size());
+    EXPECT_EQ(d, all[0]);
+  }
+}

--- a/src/Core/Datatypes/Legacy/Field/VMesh.cc
+++ b/src/Core/Datatypes/Legacy/Field/VMesh.cc
@@ -735,6 +735,14 @@ VMesh::get_neighbors(Node::array_type&, Node::index_type) const
 }
 
 void
+VMesh::get_all_neighbors(Elem::array_type& elems, DElem::index_type delem) const
+{
+  // The delem->elem lookup is already the unfiltered form of get_neighbor():
+  // there is no "which side am I on" check in it to drop.
+  get_elems(elems,delem);
+}
+
+void
 VMesh::pwl_approx_edge(std::vector<coords_type >&, Elem::index_type, unsigned int , unsigned int) const
 {
   ASSERTFAIL("VMesh interface: pwl_appprox_edge has not been implemented");

--- a/src/Core/Datatypes/Legacy/Field/VMesh.h
+++ b/src/Core/Datatypes/Legacy/Field/VMesh.h
@@ -883,6 +883,12 @@ public:
   virtual void get_neighbors(Node::array_type &nodes,
                              Node::index_type i) const;
 
+  /// Every element on a delem, i.e. the ones get_neighbor() picks between.
+  /// Unlike the calls above this does not need one of them as input, so it
+  /// works when walking the delems of a mesh rather than the elems.
+  virtual void get_all_neighbors(Elem::array_type &elems,
+                                 DElem::index_type delem) const;
+
   /// Draw non linear elements
   virtual void pwl_approx_edge(coords_array_type &coords,
                                Elem::index_type ci, unsigned int which_edge,


### PR DESCRIPTION
Fixes #2434.

## What

`get_neighbor()` and `get_neighbors()` both take a delem, but they also require one of the elements sitting on it — so you can ask *"who is on the other side of this face from me"*, but never *"who is on this face"*. That makes them awkward to use when you are walking a mesh's delems rather than its elems.

Adds the delem-only form:

```cpp
virtual void get_all_neighbors(Elem::array_type& elems, DElem::index_type delem) const;
```

## The implementation is thin, on purpose

While implementing this I found the check-free lookup already exists per mesh type — it is `get_elems(elems, delem)`, backed by `get_cells_from_face` / `get_faces_from_edge` / etc. It is just filed under the topology API and never named or documented as a neighbor call, which is presumably why it did not turn up when the issue was written.

So the base implementation forwards there rather than duplicating the traversal into thirteen mesh classes, all of which would be one-line forwards to the same primitive. Subclasses can still override if a mesh ever needs something different. Happy to expand it per-mesh if reviewers would rather see it spelled out.

## Point cloud gap

`VPointCloudMesh` had no `get_elems(..., DElem)` at all, so `get_all_neighbors` would have hit the base `ASSERTFAIL` there. Added it — node, elem and delem are all the same index in a point cloud.

## Tests

New `VMeshNeighborTests.cc`, 9 cases across TetVol, TriSurf, LatVol and PointCloud.

The main one is a property check run over every delem of a mesh: the returned set has no duplicates, every element in it genuinely lists that delem, and `get_neighbors(elems, elem, delem)` returns exactly the set minus the element you asked from. The rest pin counts on known geometry — the 6-tet cube splits into 12 boundary and 6 interior faces, the closed TriSurf cube has zero boundary edges, a 2x2x2 LatVol gives 24 boundary and 12 interior.

## Verification

Full headless build clean. All 54 unit-test binaries pass, including `Core_Datatypes_Legacy_Field_Tests`.

## Noted, not fixed

- `VMesh::size(DElem::size_type&)` returns 0 for point clouds, so a point cloud reports no delems even though delem indices are answerable. Pre-existing; the test iterates elem count rather than working around it.
- `src/Core/Datatypes/Mesh/VirtualMeshFactory.cc` has a parallel `VirtualMesh` neighbor interface, untouched here — it reads as an unfinished rewrite and is outside what #2434 asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)