### PR TITLE
CI: add an Ubuntu 26.04 preview job to the nightly Linux matrix

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -76,3 +76,33 @@ jobs:
       runner: ubuntu-24.04-arm
       variant: gui
       build-with-python: false
+
+  # ---------------------------------------------------------------------------
+  # Ubuntu 26.04 (public preview since 2026-06-11, actions/runner-images#14226).
+  # New toolchain and new system libraries; ubuntu-latest stays 24.04 until GA,
+  # so nothing above this line exercises 26.04.
+  #
+  # Same shape as the VS 2026 jobs in windows.yml: nightly-only, never in the PR
+  # tier (pr.yml), and allow-failure so a preview-image break reports red without
+  # failing the run. nightly-slack.yml names continue-on-error job failures
+  # explicitly, so these still surface in Slack.
+  #
+  # ONE job on purpose, not a gui/headless/qt6 spread. 26.04 defaults to GCC
+  # 15.2, and src/Externals/libxml2 is libxml2 2.6.22 (2005) built
+  # unconditionally for every variant -- so today every variant dies in the same
+  # place, and a spread would just buy three identical ~60-minute logs a night.
+  # The Qt5-availability question a gui job would answer is already answered
+  # cheaper: the `Prepare (linux)` step in reusable-build.yml runs its apt calls
+  # on every ubuntu runner regardless of variant, and warns if apt Qt5 is gone.
+  #
+  # Once libxml2 compiles here, widen this to mirror the x86_64 trio above (and
+  # ubuntu-26.04-arm, also in preview) -- at that point the variants diverge and
+  # each earns its slot.
+  # ---------------------------------------------------------------------------
+  linux-2604-headless:
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      runner: ubuntu-26.04
+      variant: headless
+      build-testing: true
+      allow-failure: true

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -104,9 +104,19 @@ jobs:
 
       - name: Prepare (linux)
         if: ${{ startsWith(inputs.runner, 'ubuntu') || inputs.prepare-packages }}
+        # Two apt calls, not one: apt-get installs nothing at all if any single
+        # package in the list is unavailable, so with everything in one command a
+        # Qt5 package dropped from a newer Ubuntu also silently takes out mesa,
+        # ninja and xorg-dev -- and `|| true` hides it until the build fails much
+        # later on something unrelated. Qt5 is EOL upstream and on its way out of
+        # the archive, so keep it in its own best-effort call. The Qt6 jobs get
+        # Qt from install-qt-action and never needed this half anyway.
         run: |
           sudo apt-get update
-          sudo apt-get install -y mesa-common-dev libgl1-mesa-dev mesa-utils-extra libglapi-mesa ninja-build qt5-qmake qtbase5-dev libqt5opengl5-dev libqt5svg5-dev xorg-dev libglu1-mesa-dev || true
+          sudo apt-get install -y mesa-common-dev libgl1-mesa-dev mesa-utils-extra libglapi-mesa ninja-build xorg-dev libglu1-mesa-dev \
+            || echo "::warning::Base build dependencies failed to install; the build will probably fail."
+          sudo apt-get install -y qt5-qmake qtbase5-dev libqt5opengl5-dev libqt5svg5-dev \
+            || echo "::warning::apt Qt5 packages unavailable on this image; only the Qt5 GUI jobs need them."
 
       - name: Build (Linux/macOS)
         if: ${{ runner.os != 'Windows' }}


### PR DESCRIPTION
Ubuntu 26.04 has been in [public preview since 2026-06-11](https://github.com/actions/runner-images/issues/14226). `ubuntu-latest` stays 24.04 until GA, so nothing in the matrix exercised it. Yong hit build errors on 26.04 while building #2712, which is what prompted this.

## What's here

**`linux-2604-headless` in `ccpp.yml`** — nightly + master push + `workflow_dispatch`, `allow-failure: true`. Same shape as the VS 2026 jobs in `windows.yml`: a preview-image break reports red without failing the run, and `nightly-slack.yml` already names continue-on-error job failures, so it still surfaces in Slack. Deliberately *not* in `pr.yml` — `ci-gate` is a strict required check and a preview image must not gate merges.

**One job, not a gui/headless/qt6 spread.** 26.04 defaults to GCC 15.2, and `src/Externals/libxml2` is built unconditionally for every variant, so today every variant dies in the same place; a spread would buy three identical ~60-minute logs a night. The Qt5-availability question a gui job would answer is already covered — the `Prepare (linux)` step runs its apt calls on every ubuntu runner regardless of variant and now warns if apt Qt5 is gone. The comment in the file says how to widen it (including `ubuntu-26.04-arm`, also in preview) once libxml2 clears.

**Split the linux apt call in two.** `apt-get` installs *nothing at all* if any single package in the list is unavailable, so with mesa, ninja, xorg-dev and the Qt5 packages in one command, a Qt5 package dropped from a newer Ubuntu silently takes out the base dependencies too — and the trailing `|| true` hid it until the build failed much later on something unrelated. Qt5 is EOL upstream and on its way out of the archive, so it now gets its own best-effort call with its own warning. No behaviour change on 22.04/24.04.

## The blocker this will report

`src/Externals/libxml2` is **libxml2 2.6.22, released 2005** — vendored, 269k lines, with its own hand-rolled CMakeLists (the version is set there, not in `VERSIONS.cmake`, which is why the dependency-freshness check has never flagged it). 24.04 defaults to GCC 13, the last release where the legacy-C diagnostics are warnings. GCC 14 promoted `implicit-function-declaration`, `incompatible-pointer-types`, `int-conversion`, `implicit-int` and `return-mismatch` to hard errors and moved the default dialect to C23. Not a 26.04 bug, and nothing CI config can fix — so this job is expected to be red on merge, which is what `allow-failure` is for.

Sizing the real fix, since it's cheap to record now:

- Exactly **two** consumers — `src/Core/XMLUtil/XMLUtil.cc` (31 call sites) and `src/Dataflow/Serialization/Network/Importer/NetworkIO.cc` (293, the legacy `.srn` importer). Nothing else in `src/` includes `libxml/`.
- The ~30 distinct entry points used are all mainstream tree/DOM calls that still exist in current libxml2, so a version bump is low-risk on the API side; the work is replacing the hand-rolled CMakeLists with upstream's. The vendored config enables SAX1/LEGACY/DOCB, removed in 2.14+, but SCIRun calls none of them.
- **pugixml is already vendored and already in use** for ColorMap I/O. Porting those two files to it would delete the vendored C and the libxml2 CVE tail outright, for probably comparable effort.

Stopgap for anyone who needs to build on 26.04 before that lands: gcc-13 is still on the image (13.4, 14.3 and 15.2 are all installed), so `CC=gcc-13 CXX=g++-13`.

## Testing

YAML parses and the job list is as intended; the runner labels are confirmed against actions/runner-images#14226. The job itself can only be exercised after merge (or via `workflow_dispatch` on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)