### PR TITLE
Join mesh synchronize() worker threads instead of detaching them (#2732)

### DIFF
--- a/src/Core/Datatypes/Legacy/Field/HexVolMesh.h
+++ b/src/Core/Datatypes/Legacy/Field/HexVolMesh.h
@@ -60,6 +60,7 @@
 #include <Core/Thread/Mutex.h>
 #include <Core/Thread/Parallel.h>
 #include <Core/Thread/ConditionVariable.h>
+#include <Core/Thread/ThreadGroup.h>
 #include <unordered_map>
 
 #include <set>
@@ -3415,6 +3416,10 @@ HexVolMesh<Basis>::synchronize(mask_type sync)
            Mesh::NODE_NEIGHBORS_E|Mesh::BOUNDING_BOX_E|
            Mesh::NODE_LOCATE_E|Mesh::ELEM_LOCATE_E);
 
+  /// Declared before the lock: these workers hold a raw `this` and must be joined
+  /// before synchronize() returns, but joining while the lock is held deadlocks. #2732
+  Core::Thread::JoiningThreadGroup syncWorkers;
+
   Core::Thread::UniqueLock lock(synchronize_lock_.get());
 
   // Only sync was hasn't been synched
@@ -3431,7 +3436,7 @@ HexVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::EDGES_E;
     Synchronize syncclass(*this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::FACES_E)
@@ -3445,7 +3450,7 @@ HexVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::FACES_E;
     Synchronize syncclass(*this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::NODE_NEIGHBORS_E)
@@ -3459,7 +3464,7 @@ HexVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::NODE_NEIGHBORS_E;
     Synchronize syncclass(*this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::BOUNDING_BOX_E)
@@ -3473,7 +3478,7 @@ HexVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::BOUNDING_BOX_E;
     Synchronize syncclass(*this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::NODE_LOCATE_E)
@@ -3487,7 +3492,7 @@ HexVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::NODE_LOCATE_E;
     Synchronize syncclass(*this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::ELEM_LOCATE_E)
@@ -3501,7 +3506,7 @@ HexVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::ELEM_LOCATE_E;
     Synchronize syncclass(*this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   // Wait until threads are done
@@ -3509,6 +3514,12 @@ HexVolMesh<Basis>::synchronize(mask_type sync)
   {
     synchronize_cond_.wait(lock);
   }
+
+  // A worker sets its synchronized_ bit before it is done with the mesh, and one whose
+  // tables were claimed by another thread never sets a bit at all -- so the wait above
+  // does not cover either of them. #2732
+  lock.unlock();
+  syncWorkers.joinAll();
 
   return (true);
 }

--- a/src/Core/Datatypes/Legacy/Field/PrismVolMesh.h
+++ b/src/Core/Datatypes/Legacy/Field/PrismVolMesh.h
@@ -58,6 +58,7 @@
 #include <unordered_map>
 #include <Core/Thread/Mutex.h>
 #include <Core/Thread/ConditionVariable.h>
+#include <Core/Thread/ThreadGroup.h>
 
 #include <set>
 
@@ -3074,6 +3075,10 @@ PrismVolMesh<Basis>::synchronize(mask_type sync)
            Mesh::NODE_NEIGHBORS_E|Mesh::BOUNDING_BOX_E|
            Mesh::NODE_LOCATE_E|Mesh::ELEM_LOCATE_E);
 
+  /// Declared before the lock: these workers hold a raw `this` and must be joined
+  /// before synchronize() returns, but joining while the lock is held deadlocks. #2732
+  Core::Thread::JoiningThreadGroup syncWorkers;
+
   Core::Thread::UniqueLock lock(synchronize_lock_.get());
 
   // Only sync was hasn't been synched
@@ -3090,7 +3095,7 @@ PrismVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::EDGES_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::FACES_E)
@@ -3104,7 +3109,7 @@ PrismVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::FACES_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::NODE_NEIGHBORS_E)
@@ -3118,7 +3123,7 @@ PrismVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::NODE_NEIGHBORS_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::BOUNDING_BOX_E)
@@ -3132,7 +3137,7 @@ PrismVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::BOUNDING_BOX_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::NODE_LOCATE_E)
@@ -3146,7 +3151,7 @@ PrismVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::NODE_LOCATE_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::ELEM_LOCATE_E)
@@ -3160,7 +3165,7 @@ PrismVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::ELEM_LOCATE_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   // Wait until threads are done
@@ -3168,6 +3173,12 @@ PrismVolMesh<Basis>::synchronize(mask_type sync)
   {
     synchronize_cond_.wait(lock);
   }
+
+  // A worker sets its synchronized_ bit before it is done with the mesh, and one whose
+  // tables were claimed by another thread never sets a bit at all -- so the wait above
+  // does not cover either of them. #2732
+  lock.unlock();
+  syncWorkers.joinAll();
 
   return (true);
 }

--- a/src/Core/Datatypes/Legacy/Field/QuadSurfMesh.h
+++ b/src/Core/Datatypes/Legacy/Field/QuadSurfMesh.h
@@ -55,6 +55,7 @@
 
 #include <Core/Thread/Mutex.h>
 #include <Core/Thread/ConditionVariable.h>
+#include <Core/Thread/ThreadGroup.h>
 #include <unordered_map>
 #include <Core/Persistent/PersistentSTL.h>
 
@@ -2614,6 +2615,10 @@ QuadSurfMesh<Basis>::synchronize(mask_type sync)
 
   {
 
+  /// Declared before the lock: these workers hold a raw `this` and must be joined
+  /// before synchronize() returns, but joining while the lock is held deadlocks. #2732
+  Core::Thread::JoiningThreadGroup syncWorkers;
+
   Core::Thread::UniqueLock lock(synchronize_lock_);
 
   // Only sync what hasn't been synched
@@ -2636,7 +2641,7 @@ QuadSurfMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::EDGES_E;
     Synchronize syncclass(this,tosync);
-    SCIRun::Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::NORMALS_E)
@@ -2650,7 +2655,7 @@ QuadSurfMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::NORMALS_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::NODE_NEIGHBORS_E)
@@ -2664,7 +2669,7 @@ QuadSurfMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::NODE_NEIGHBORS_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::BOUNDING_BOX_E)
@@ -2678,7 +2683,7 @@ QuadSurfMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::BOUNDING_BOX_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::NODE_LOCATE_E)
@@ -2692,7 +2697,7 @@ QuadSurfMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::NODE_LOCATE_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::ELEM_LOCATE_E)
@@ -2706,7 +2711,7 @@ QuadSurfMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::ELEM_LOCATE_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   // Wait until threads are done
@@ -2714,6 +2719,12 @@ QuadSurfMesh<Basis>::synchronize(mask_type sync)
     {
       synchronize_cond_.wait(lock);
     }
+
+  // A worker sets its synchronized_ bit before it is done with the mesh, and one whose
+  // tables were claimed by another thread never sets a bit at all -- so the wait above
+  // does not cover either of them. #2732
+  lock.unlock();
+  syncWorkers.joinAll();
 
   }
 

--- a/src/Core/Datatypes/Legacy/Field/Tests/CMakeLists.txt
+++ b/src/Core/Datatypes/Legacy/Field/Tests/CMakeLists.txt
@@ -35,6 +35,7 @@ SET(Core_Datatypes_Legacy_Field_Tests_SRCS
   #MeshFactoryTests.cc
   #TriSurfMeshTests.cc
   TetVolMeshTests.cc
+  MeshSynchronizeThreadingTests.cc
 )
 
 SCIRUN_ADD_UNIT_TEST(Core_Datatypes_Legacy_Field_Tests ${Core_Datatypes_Legacy_Field_Tests_SRCS})

--- a/src/Core/Datatypes/Legacy/Field/Tests/MeshSynchronizeThreadingTests.cc
+++ b/src/Core/Datatypes/Legacy/Field/Tests/MeshSynchronizeThreadingTests.cc
@@ -1,0 +1,115 @@
+/*
+   For more information, please see: http://software.sci.utah.edu
+
+   The MIT License
+
+   Copyright (c) 2020 Scientific Computing and Imaging Institute,
+   University of Utah.
+
+   Permission is hereby granted, free of charge, to any person obtaining a
+   copy of this software and associated documentation files (the "Software"),
+   to deal in the Software without restriction, including without limitation
+   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+   and/or sell copies of the Software, and to permit persons to whom the
+   Software is furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+*/
+
+/// Regression test for #2732: mesh synchronize() used to detach its Synchronize
+/// workers, which hold a raw mesh pointer, so one could still be inside the mesh's
+/// mutex after the mesh was destroyed. Before the fix this aborts within a few
+/// hundred iterations -- "mutex lock failed: Invalid argument", a synchronization
+/// assertion, or a length_error from a table read during teardown.
+
+#include <gtest/gtest.h>
+
+#include <Core/Basis/TriLinearLgn.h>
+#include <Core/Basis/TetLinearLgn.h>
+#include <Core/Datatypes/Legacy/Field/TriSurfMesh.h>
+#include <Core/Datatypes/Legacy/Field/TetVolMesh.h>
+
+#include <memory>
+#include <random>
+#include <thread>
+#include <vector>
+
+using namespace SCIRun;
+using namespace SCIRun::Core::Geometry;
+
+namespace
+{
+  const int iterations = 200;
+  const int threadsPerMesh = 4;
+
+  /// Hammer synchronize() from several threads, then destroy the mesh immediately.
+  template <typename MeshT, typename BuildFunc>
+  void stressSynchronize(BuildFunc build)
+  {
+    for (int i = 0; i < iterations; ++i)
+    {
+      auto mesh = std::make_unique<MeshT>();
+      build(*mesh);
+
+      std::vector<std::thread> callers;
+      for (int t = 0; t < threadsPerMesh; ++t)
+      {
+        auto* raw = mesh.get();
+        callers.emplace_back([raw, t]
+        {
+          raw->synchronize(t % 2 ? Mesh::NODE_LOCATE_E
+                                 : (Mesh::NODE_LOCATE_E | Mesh::NORMALS_E));
+        });
+      }
+      for (auto& c : callers)
+        c.join();
+
+      /// Any worker still holding the mesh now has a dangling pointer.
+      mesh.reset();
+    }
+  }
+}
+
+TEST(MeshSynchronizeThreadingTest, TriSurfMeshSurvivesConcurrentSynchronize)
+{
+  using MeshT = TriSurfMesh<Core::Basis::TriLinearLgn<Point>>;
+  std::mt19937 rng(7);
+  stressSynchronize<MeshT>([&rng](MeshT& mesh)
+  {
+    const int nodes = 60;
+    for (int n = 0; n < nodes; ++n)
+      mesh.add_point(Point((rng() % 1000) / 10.0, (rng() % 1000) / 10.0, (rng() % 1000) / 10.0));
+    for (int n = 0; n + 2 < nodes; ++n)
+      mesh.add_triangle(MeshT::Node::index_type(n),
+                        MeshT::Node::index_type(n + 1),
+                        MeshT::Node::index_type(n + 2));
+  });
+  SUCCEED();
+}
+
+TEST(MeshSynchronizeThreadingTest, TetVolMeshSurvivesConcurrentSynchronize)
+{
+  using MeshT = TetVolMesh<Core::Basis::TetLinearLgn<Point>>;
+  std::mt19937 rng(11);
+  stressSynchronize<MeshT>([&rng](MeshT& mesh)
+  {
+    const int nodes = 60;
+    for (int n = 0; n < nodes; ++n)
+      mesh.add_point(Point((rng() % 1000) / 10.0, (rng() % 1000) / 10.0, (rng() % 1000) / 10.0));
+    for (int n = 0; n + 3 < nodes; ++n)
+      mesh.add_tet(MeshT::Node::index_type(n),
+                   MeshT::Node::index_type(n + 1),
+                   MeshT::Node::index_type(n + 2),
+                   MeshT::Node::index_type(n + 3));
+  });
+  SUCCEED();
+}

--- a/src/Core/Datatypes/Legacy/Field/TetVolMesh.h
+++ b/src/Core/Datatypes/Legacy/Field/TetVolMesh.h
@@ -60,6 +60,7 @@
 #include <unordered_map>
 #include <Core/Thread/Mutex.h>
 #include <Core/Thread/ConditionVariable.h>
+#include <Core/Thread/ThreadGroup.h>
 
 #include <set>
 
@@ -3189,6 +3190,10 @@ TetVolMesh<Basis>::synchronize(mask_type sync)
            Mesh::NODE_NEIGHBORS_E|Mesh::BOUNDING_BOX_E|
            Mesh::NODE_LOCATE_E|Mesh::ELEM_LOCATE_E);
 
+  /// Declared before the lock: these workers hold a raw `this` and must be joined
+  /// before synchronize() returns, but joining while the lock is held deadlocks. #2732
+  Core::Thread::JoiningThreadGroup syncWorkers;
+
   Core::Thread::UniqueLock lock(synchronize_lock_.get());
 
   // Only sync was hasn't been synched
@@ -3205,7 +3210,7 @@ TetVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::EDGES_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::FACES_E)
@@ -3219,7 +3224,7 @@ TetVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::FACES_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::NODE_NEIGHBORS_E)
@@ -3233,7 +3238,7 @@ TetVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::NODE_NEIGHBORS_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::BOUNDING_BOX_E)
@@ -3247,7 +3252,7 @@ TetVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::BOUNDING_BOX_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::NODE_LOCATE_E)
@@ -3261,7 +3266,7 @@ TetVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::NODE_LOCATE_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::ELEM_LOCATE_E)
@@ -3275,7 +3280,7 @@ TetVolMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::ELEM_LOCATE_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   // Wait until threads are done
@@ -3283,6 +3288,12 @@ TetVolMesh<Basis>::synchronize(mask_type sync)
   {
     synchronize_cond_.wait(lock);
   }
+
+  // A worker sets its synchronized_ bit before it is done with the mesh, and one whose
+  // tables were claimed by another thread never sets a bit at all -- so the wait above
+  // does not cover either of them. #2732
+  lock.unlock();
+  syncWorkers.joinAll();
 
   return (true);
 }

--- a/src/Core/Datatypes/Legacy/Field/TriSurfMesh.h
+++ b/src/Core/Datatypes/Legacy/Field/TriSurfMesh.h
@@ -56,6 +56,7 @@
 
 #include <Core/Thread/Mutex.h>
 #include <Core/Thread/ConditionVariable.h>
+#include <Core/Thread/ThreadGroup.h>
 #include <unordered_map>
 
 #include <set>
@@ -2434,6 +2435,10 @@ TriSurfMesh<Basis>::synchronize(mask_type sync)
            Mesh::ELEM_NEIGHBORS_E|
            Mesh::NODE_LOCATE_E|Mesh::ELEM_LOCATE_E);
 
+  /// Declared before the lock: these workers hold a raw `this` and must be joined
+  /// before synchronize() returns, but joining while the lock is held deadlocks. #2732
+  Core::Thread::JoiningThreadGroup syncWorkers;
+
   Core::Thread::UniqueLock lock(synchronize_lock_.get());
 
   // Only sync was hasn't been synched
@@ -2450,7 +2455,7 @@ TriSurfMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::EDGES_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::NORMALS_E)
@@ -2464,7 +2469,7 @@ TriSurfMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::NORMALS_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::NODE_NEIGHBORS_E)
@@ -2478,7 +2483,7 @@ TriSurfMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::NODE_NEIGHBORS_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::ELEM_NEIGHBORS_E)
@@ -2492,7 +2497,7 @@ TriSurfMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::ELEM_NEIGHBORS_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::BOUNDING_BOX_E)
@@ -2506,7 +2511,7 @@ TriSurfMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::BOUNDING_BOX_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::NODE_LOCATE_E)
@@ -2520,7 +2525,7 @@ TriSurfMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::NODE_LOCATE_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   if (sync == Mesh::ELEM_LOCATE_E)
@@ -2534,7 +2539,7 @@ TriSurfMesh<Basis>::synchronize(mask_type sync)
   {
     mask_type tosync = Mesh::ELEM_LOCATE_E;
     Synchronize syncclass(this,tosync);
-    Core::Thread::Util::launchAsyncThread(syncclass);
+    syncWorkers.launch(syncclass);
   }
 
   // Wait until threads are done
@@ -2542,6 +2547,12 @@ TriSurfMesh<Basis>::synchronize(mask_type sync)
   {
     synchronize_cond_.wait(lock);
   }
+
+  // A worker sets its synchronized_ bit before it is done with the mesh, and one whose
+  // tables were claimed by another thread never sets a bit at all -- so the wait above
+  // does not cover either of them. #2732
+  lock.unlock();
+  syncWorkers.joinAll();
 
   return (true);
 }

--- a/src/Core/Thread/CMakeLists.txt
+++ b/src/Core/Thread/CMakeLists.txt
@@ -39,6 +39,7 @@ SET(Core_Thread_HEADERS
   Mutex.h
   Parallel.h
   share.h
+  ThreadGroup.h
 )
 
 SCIRUN_ADD_LIBRARY(Core_Thread

--- a/src/Core/Thread/ThreadGroup.h
+++ b/src/Core/Thread/ThreadGroup.h
@@ -1,0 +1,79 @@
+/*
+   For more information, please see: http://software.sci.utah.edu
+
+   The MIT License
+
+   Copyright (c) 2020 Scientific Computing and Imaging Institute,
+   University of Utah.
+
+   Permission is hereby granted, free of charge, to any person obtaining a
+   copy of this software and associated documentation files (the "Software"),
+   to deal in the Software without restriction, including without limitation
+   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+   and/or sell copies of the Software, and to permit persons to whom the
+   Software is furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+*/
+
+
+#ifndef CORE_THREAD_THREADGROUP_H
+#define CORE_THREAD_THREADGROUP_H
+
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace SCIRun {
+namespace Core {
+namespace Thread {
+
+  /// Workers that borrow state from their launcher -- a raw `this`, a reference to a
+  /// local -- must not outlive the call that started them. This owns them and joins
+  /// before it goes away, which `Util::launchAsyncThread` (detach) cannot do. #2732
+  ///
+  /// Declare it *before* any lock the workers need to acquire, so that the destructor
+  /// runs after the lock is released; joining while holding that lock deadlocks.
+  class JoiningThreadGroup
+  {
+  public:
+    JoiningThreadGroup() = default;
+    ~JoiningThreadGroup() { joinAll(); }
+
+    JoiningThreadGroup(const JoiningThreadGroup&) = delete;
+    JoiningThreadGroup& operator=(const JoiningThreadGroup&) = delete;
+
+    template <typename Callable>
+    void launch(Callable&& callable)
+    {
+      threads_.emplace_back(std::forward<Callable>(callable));
+    }
+
+    void joinAll()
+    {
+      for (auto& t : threads_)
+      {
+        if (t.joinable())
+          t.join();
+      }
+      threads_.clear();
+    }
+
+    bool empty() const { return threads_.empty(); }
+
+  private:
+    std::vector<std::thread> threads_;
+  };
+
+}}}
+
+#endif

--- a/src/Interface/Modules/Render/ES/systems/RenderTransBasicSys.cc
+++ b/src/Interface/Modules/Render/ES/systems/RenderTransBasicSys.cc
@@ -63,6 +63,10 @@
 #include "../comp/LightingUniforms.h"
 #include "../comp/ClippingPlaneUniforms.h"
 
+#include <Core/Logging/Log.h>
+
+#include <set>
+
 namespace es = spire;
 namespace shaders = spire;
 using namespace SCIRun::Graphics::Datatypes;
@@ -138,6 +142,15 @@ private:
 
   std::vector<SortedObject> sortedObjects;
 
+  /// Passes already reported as unsortable, so the warning doesn't repeat every frame.
+  std::set<std::string> warnedPasses;
+
+  void warnUnsortable(const std::string& passName, const std::string& reason)
+  {
+    if (warnedPasses.insert(passName).second)
+      logWarning("ViewScene: transparency sort skipped for \"{}\" ({}); drawing unsorted.", passName, reason);
+  }
+
   class DepthIndex {
   public:
     size_t mIndex;
@@ -180,26 +193,61 @@ private:
     const spire::ComponentGroup<SpireSubPass>& pass,
     const spire::ComponentGroup<ren::StaticIBOMan>&)
   {
-    char* vbo_buffer = reinterpret_cast<char*>(pass.front().vbo.data->getBuffer());
-    uint32_t* ibo_buffer = reinterpret_cast<uint32_t*>(pass.front().ibo.data->getBuffer());
-    size_t num_triangles = pass.front().ibo.data->getBufferSize() / (sizeof(uint32_t) * 3);
+    const auto& subPass = pass.front();
+    const auto& passName = subPass.ibo.name;
+
+    // This reads the IBO as raw uint32 triples indexing straight into the VBO, so anything that
+    // breaks that assumption -- narrower indices, a stride too small to hold a vec3, an index past
+    // the last vertex -- reads off the end of the VBO and kills the process. #2700.
+    if (!subPass.vbo.data || !subPass.ibo.data)
+    {
+      warnUnsortable(passName, "missing geometry buffer");
+      return ibo.front().glid;
+    }
+
+    char* vbo_buffer = reinterpret_cast<char*>(subPass.vbo.data->getBuffer());
+    uint32_t* ibo_buffer = reinterpret_cast<uint32_t*>(subPass.ibo.data->getBuffer());
+    size_t num_triangles = subPass.ibo.data->getBufferSize() / (sizeof(uint32_t) * 3);
 
     size_t stride_vbo = 0;
-    for (auto a : pass.front().vbo.attributes)
+    for (auto a : subPass.vbo.attributes)
       stride_vbo += a.sizeInBytes;
+
+    if (subPass.ibo.indexSize != sizeof(uint32_t))
+    {
+      warnUnsortable(passName, "index size is not 32-bit");
+      return ibo.front().glid;
+    }
+
+    if (stride_vbo < 3 * sizeof(float))
+    {
+      warnUnsortable(passName, "vertex stride too small for a position");
+      return ibo.front().glid;
+    }
+
+    const size_t num_vertices = subPass.vbo.data->getBufferSize() / stride_vbo;
 
     std::vector<DepthIndex> rel_depth(num_triangles);
 
 
     for (size_t j = 0; j < num_triangles; j++)
     {
-      float* vertex1 = reinterpret_cast<float*>(vbo_buffer + stride_vbo * (ibo_buffer[j * 3]));
+      const uint32_t index1 = ibo_buffer[j * 3];
+      const uint32_t index2 = ibo_buffer[j * 3 + 1];
+      const uint32_t index3 = ibo_buffer[j * 3 + 2];
+      if (index1 >= num_vertices || index2 >= num_vertices || index3 >= num_vertices)
+      {
+        warnUnsortable(passName, "index out of range of the vertex buffer");
+        return ibo.front().glid;
+      }
+
+      float* vertex1 = reinterpret_cast<float*>(vbo_buffer + stride_vbo * index1);
       Core::Geometry::Point node1(vertex1[0], vertex1[1], vertex1[2]);
 
-      float* vertex2 = reinterpret_cast<float*>(vbo_buffer + stride_vbo * (ibo_buffer[j * 3 + 1]));
+      float* vertex2 = reinterpret_cast<float*>(vbo_buffer + stride_vbo * index2);
       Core::Geometry::Point node2(vertex2[0], vertex2[1], vertex2[2]);
 
-      float* vertex3 = reinterpret_cast<float*>(vbo_buffer + stride_vbo * (ibo_buffer[j * 3 + 2]));
+      float* vertex3 = reinterpret_cast<float*>(vbo_buffer + stride_vbo * index3);
       Core::Geometry::Point node3(vertex3[0], vertex3[1], vertex3[2]);
 
       rel_depth[j].mDepth = Core::Geometry::Dot(dir, node1) + Core::Geometry::Dot(dir, node2) + Core::Geometry::Dot(dir, node3);
@@ -208,21 +256,21 @@ private:
 
     std::sort(rel_depth.begin(), rel_depth.end());
 
-    std::vector<char> sorted_buffer(pass.front().ibo.data->getBufferSize());
-    char* ibuffer = reinterpret_cast<char*>(pass.front().ibo.data->getBuffer());
+    std::vector<char> sorted_buffer(subPass.ibo.data->getBufferSize());
+    char* ibuffer = reinterpret_cast<char*>(subPass.ibo.data->getBuffer());
     char* sbuffer = !sorted_buffer.empty() ? reinterpret_cast<char*>(&sorted_buffer[0]) : nullptr;
     GLuint result = ibo.front().glid;
     if (sbuffer && num_triangles > 0)
     {
-      size_t tri_size = pass.front().ibo.data->getBufferSize() / num_triangles;
+      size_t tri_size = subPass.ibo.data->getBufferSize() / num_triangles;
 
       for (size_t j = 0; j < num_triangles; j++)
       {
         memcpy(sbuffer + j * tri_size, ibuffer + rel_depth[j].mIndex * tri_size, tri_size);
       }
 
-      std::string transIBOName = pass.front().ibo.name + "trans";
-      result = addIBO(sbuffer, pass.front().ibo.data->getBufferSize());
+      std::string transIBOName = passName + "trans";
+      result = addIBO(sbuffer, subPass.ibo.data->getBufferSize());
     }
 
     return result;


### PR DESCRIPTION
`synchronize()` on the legacy mesh classes launches `Synchronize` workers through [`Util::launchAsyncThread`](https://github.com/SCIInstitute/SCIRun/blob/master/src/Core/Thread/Mutex.h#L77), which creates a `std::thread` and **detaches** it. Those workers hold a raw mesh pointer, and nothing guarantees they are finished with the mesh when `synchronize()` returns:

- the caller's wait loop only waits on the `synchronized_` bits, and a worker sets its bit *before* it unlocks the mutex and returns;
- a worker whose tables were already claimed by another thread never sets a bit at all, so the wait does not cover it in the first place.

Either one can still be inside `mesh_->synchronize_lock_` after the mesh is destroyed. What that does depends on what the allocator did with the memory — an `EINVAL` from `pthread_mutex_lock`, a fault, or garbage read out of a half-destroyed table.

## Reproduction

`setuptdcs_colin27_patchelc`, the network that SEGFAULTs on the mac nightly, has **two `SetupTDCS` modules** fed by the same three `ReadField`s, so both run `create_lhs` concurrently against the same shared meshes. Running it locally on an unmodified build: **1 abort in 24 runs**.

```
libc++abi: terminating due to uncaught exception of type
  std::__1::system_error: mutex lock failed: Invalid argument

std::mutex::lock() +40
TriSurfMesh<TriLinearLgn<Point>>::Synchronize::operator()() +296
std::__thread_proxy<...> +52
```

A detached worker locking a mutex that no longer exists.

## The change

`Core::Thread::JoiningThreadGroup` (new, `Core/Thread/ThreadGroup.h`) owns the workers and joins them. The five mesh classes that had the detach — `TriSurf`, `TetVol`, `QuadSurf`, `HexVol`, `PrismVol` — now use it instead of duplicating a thread vector and a join loop apiece.

It is declared *ahead of* the lock in each `synchronize()`, so that the destructor (the safety net for any future early return) runs after the lock is released — joining while holding that lock would deadlock. `joinAll()` is still called explicitly after `lock.unlock()` so the ordering is visible at the call site rather than implied by declaration order.

`Util::launchAsyncThread` itself is left alone; its three other callers are out of scope here.

## Testing

New `MeshSynchronizeThreadingTests.cc` hammers `synchronize()` from four threads and destroys the mesh immediately, 200 iterations, for `TriSurfMesh` and `TetVolMesh`.

| | result |
|---|---|
| against the current headers | **10 of 10 runs fail** — the same `EINVAL` abort, plus `Must call synchronize NODES_E`/`FACES_E` assertions and a `std::length_error` from a table read during teardown |
| with this change | 10 of 10 pass |

47 ms for both cases, so it is cheap enough to leave in the unit suite.

One caveat on verification: I could not rebuild the full app locally to re-run the regression network after the fix — `bin/SCIRun` cannot reconfigure since #2719 moved libxml2 to the Superbuild, and `src/CMakeLists.txt:232` fails with an empty `LibXml2_DIR`. The before/after evidence above comes from the unit test and a standalone harness linked against the rebuilt `Core_Datatypes_Legacy_Field`, not from the network itself. The nightly is the real check.

Fixes #2732.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
