### PR TITLE
CI: move the nightly tag on publish, prune stale-scheme assets

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -40,6 +40,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      # softprops/action-gh-release only creates the `nightly` tag the first
+      # time it publishes to it; once the tag exists, later runs update the
+      # release body/assets but never move the tag itself, so `git checkout
+      # nightly` silently pins you to whatever commit first created it. Force
+      # the ref to HEAD every run. Safe from a trigger loop: mac.yml/windows.yml
+      # only fire on `v*` tag pushes, not on `nightly`.
+      - name: Move the nightly tag to this commit
+        if: ${{ inputs.channel == 'nightly' }}
+        run: |
+          git tag --force nightly "${{ github.sha }}"
+          git push --force origin refs/tags/nightly
+
       # No merge-multiple: every GUI job emits an identically-named installer
       # (SCIRun-<ver>-win64.exe / SCIRun-<ver>-Darwin.pkg), so flattening would
       # clobber. Land each artifact in its own dist/<artifact-name>/ subdir.
@@ -101,6 +113,35 @@ jobs:
           python3 -c 'import json,sys; print(json.dumps(dict(l.rstrip("\n").split("\t") for l in open("names.tsv"))))' \
             > names.json
           cat names.json
+
+      - name: Delete stale same-platform assets
+        if: ${{ inputs.channel == 'nightly' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -eu
+          # The upload step below only replaces assets whose name matches one
+          # we're producing this run, so anything orphaned by a naming change
+          # (job-named installers pre-#2565, a retired OS floor, ...) sits on
+          # the release forever. A single run only ever builds one platform,
+          # so "same extension, not in this run's output" is a safe stand-in
+          # for "belongs to this platform and is now stale".
+          exts=$(cut -f2 names.tsv | sed -E 's/.*\././' | sort -u)
+          current=$(cut -f2 names.tsv)
+
+          gh release view nightly --repo "$REPO" --json assets -q '.assets[].name' \
+            > existing-assets.txt 2>/dev/null || : > existing-assets.txt
+
+          while IFS= read -r name; do
+            [ -n "$name" ] || continue
+            ext=".${name##*.}"
+            if printf '%s\n' "$exts" | grep -qxF "$ext" \
+               && ! printf '%s\n' "$current" | grep -qxF "$name"; then
+              echo "Deleting stale asset: $name"
+              gh release delete-asset nightly "$name" --repo "$REPO" -y || true
+            fi
+          done < existing-assets.txt
 
       - name: Generate nightly release notes
         if: ${{ inputs.channel == 'nightly' }}


### PR DESCRIPTION
## Summary
- The `nightly` git tag has been pinned at its very first publish commit (`f691af07`, 2026-08-08) ever since, because `softprops/action-gh-release` only creates a tag the first time it publishes to it and never moves an existing one — every subsequent nightly run refreshed the release body/assets but left `git checkout nightly` pointing at 3-week-old source. Now force-move the tag to `HEAD` on every nightly publish.
- The asset-rename in f818b35e4 switched installer names to a measured slug (`SCIRun-nightly-<slug>.<ext>`), but the upload step only replaces assets with matching filenames, so the old job-named installers (`SCIRunMacInstaller.pkg`, `SCIRunWindowsInstaller_qt5.exe`, ...) never got removed and just sat alongside the new ones. Now delete any existing release asset that shares this run's platform (same file extension) but isn't part of this run's fresh output before publishing.

## Test plan
- [ ] Trigger a nightly run (mac and windows) via `workflow_dispatch` or wait for the schedule, and confirm:
  - [ ] `refs/tags/nightly` moves to the run's commit
  - [ ] the old-scheme `.pkg`/`.exe` assets are gone from the release after the corresponding platform's run
  - [ ] the release still contains all expected current-scheme assets for both platforms (mac run must not touch windows assets and vice versa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)